### PR TITLE
feat: Add LLama 3.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for Llama 3.2 model
+- New `/model <modelName>` command to switch between 'llama3.1' and 'llama3.2'
+
 ## [1.5.0] - 2024-09-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ local LLMs only. To achieve this, it is integrating with Ollama.
 
 1. Install and run [Ollama](https://ollama.com)
 2. Download LLama 3.1 8B model in Ollama: ```ollama run llama3.1```
-3. Install Jarvis plugin in your Jetbrains IDE:
+3. Download LLama 3.2 8B model in Ollama: ```ollama run llama3.2```
+4. Install Jarvis plugin in your Jetbrains IDE:
    - Using the IDE built-in plugin system: <kbd>Settings/Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>Marketplace</kbd> > <kbd>Search for "jarvis"</kbd> >
      <kbd>Install</kbd>
    - Manually: Download the [latest release](https://github.com/fmueller/jarvis/releases/latest) and install it manually using
@@ -24,3 +25,12 @@ local LLMs only. To achieve this, it is integrating with Ollama.
 ## License
 
 This project is licensed under the [MIT](LICENSE)
+
+## Help
+
+Available commands:
+
+- ```/help``` or ```/?``` - Shows this help message
+- ```/new``` - Starts a new conversation
+- ```/plain``` - Sends a chat message without code context
+- ```/model <modelName>``` - Changes the model to use ('llama3.1' or 'llama3.2')

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
@@ -124,6 +124,7 @@ object OllamaService {
     }
 
     private var assistant = createAiService()
+    private var modelName = "llama3.1"
 
     fun clearChatMemory() {
         assistant = createAiService()
@@ -214,7 +215,7 @@ object OllamaService {
                 OllamaStreamingChatModel.builder()
                     .timeout(Duration.ofMinutes(5))
                     .baseUrl("http://localhost:11434")
-                    .modelName("llama3.1")
+                    .modelName(modelName)
                     .build()
             )
             .systemMessageProvider { chatMemoryId -> systemPrompt }
@@ -224,5 +225,10 @@ object OllamaService {
                     .build()
             )
             .build()
+    }
+
+    fun setModel(newModelName: String) {
+        modelName = newModelName
+        assistant = createAiService()
     }
 }

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
@@ -123,7 +123,15 @@ object OllamaService {
         fun chat(message: String): TokenStream
     }
 
-    private var modelName = "llama3.1"
+    var modelName: String = "llama3.1"
+        set(value) {
+            if (value != "llama3.1" && value != "llama3.2") {
+                throw IllegalArgumentException("Invalid model name: $value")
+            }
+            field = value
+            assistant = createAiService()
+        }
+
     private var assistant = createAiService()
 
     fun clearChatMemory() {
@@ -225,10 +233,5 @@ object OllamaService {
                     .build()
             )
             .build()
-    }
-
-    fun setModel(newModelName: String) {
-        modelName = newModelName
-        assistant = createAiService()
     }
 }

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
@@ -123,8 +123,8 @@ object OllamaService {
         fun chat(message: String): TokenStream
     }
 
-    private var assistant = createAiService()
     private var modelName = "llama3.1"
+    private var assistant = createAiService()
 
     fun clearChatMemory() {
         assistant = createAiService()

--- a/src/main/kotlin/com/github/fmueller/jarvis/commands/ModelCommand.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/commands/ModelCommand.kt
@@ -8,7 +8,7 @@ class ModelCommand(private val modelName: String) : SlashCommand {
 
     override suspend fun run(conversation: Conversation): Conversation {
         if (modelName == "llama3.1" || modelName == "llama3.2") {
-            OllamaService.setModel(modelName)
+            OllamaService.modelName = modelName
             conversation.addMessage(Message.fromAssistant("Model changed to $modelName"))
         } else {
             conversation.addMessage(Message.fromAssistant("Invalid model name: $modelName"))

--- a/src/main/kotlin/com/github/fmueller/jarvis/commands/ModelCommand.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/commands/ModelCommand.kt
@@ -1,0 +1,18 @@
+package com.github.fmueller.jarvis.commands
+
+import com.github.fmueller.jarvis.ai.OllamaService
+import com.github.fmueller.jarvis.conversation.Conversation
+import com.github.fmueller.jarvis.conversation.Message
+
+class ModelCommand(private val modelName: String) : SlashCommand {
+
+    override suspend fun run(conversation: Conversation): Conversation {
+        if (modelName == "llama3.1" || modelName == "llama3.2") {
+            OllamaService.setModel(modelName)
+            conversation.addMessage(Message.fromAssistant("Model changed to $modelName"))
+        } else {
+            conversation.addMessage(Message.fromAssistant("Invalid model name: $modelName"))
+        }
+        return conversation
+    }
+}

--- a/src/main/kotlin/com/github/fmueller/jarvis/commands/SlashCommandParser.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/commands/SlashCommandParser.kt
@@ -16,6 +16,11 @@ object SlashCommandParser {
             return PlainChatCommand()
         }
 
+        if (trimmedMessage.startsWith("/model ")) {
+            val modelName = trimmedMessage.removePrefix("/model ").trim()
+            return ModelCommand(modelName)
+        }
+
         return ChatCommand()
     }
 }

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
@@ -41,6 +41,7 @@ data class Message(
             - ```/help``` or ```/?``` - Shows this help message
             - ```/new``` - Starts a new conversation
             - ```/plain``` - Sends a chat message without code context
+            - ```/model <modelName>``` - Changes the model to use ('llama3.1' or 'llama3.2')
             """.trimIndent()
         )
 


### PR DESCRIPTION
Fixes #62

Add support for Llama 3.2 model and implement `/model <modelName>` command.

* **OllamaService.kt**: Add `modelName` property to store the current model name. Update `createAiService` method to use `modelName` property. Add `setModel` method to change the model name and recreate the assistant.
* **ModelCommand.kt**: Implement `ModelCommand` class to handle the `/model <modelName>` command. Validate `modelName` and call `OllamaService.setModel` if valid. Add an error message to the conversation if the `modelName` is invalid.
* **SlashCommandParser.kt**: Add a case to parse the `/model <modelName>` command and return a `ModelCommand`.
* **README.md**: Update installation instructions to include downloading the Llama 3.2 model. Add a description of the `/model <modelName>` command to the help section.
* **CHANGELOG.md**: Add an entry for the new `/model <modelName>` command and Llama 3.2 support.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fmueller/jarvis/pull/67?shareId=34aa3eff-5ecf-41ce-8608-26d73dffc599).