### PR TITLE
Fix message panel UI update bug

### DIFF
--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
@@ -106,7 +106,7 @@ class MessagePanel(initialMessage: Message, project: Project) : JPanel(), Dispos
                     val newContent = newParsedContent.subList(i, newParsedContent.size)
                     parsed.subList(i, parsed.size).clear()
                     parsed.addAll(newContent)
-                    removeAllComponentsAfter(i + 1)
+                    removeAllComponentsAfter(i)
                     render(newContent)
                     break
                 }

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
@@ -28,6 +28,15 @@ class MessagePanelTest : BasePlatformTestCase() {
         assertEquals("Hi", messagePanel.message.content)
     }
 
+    fun `test component count remains consistent when content type changes`() {
+        assertEquals(2, messagePanel.componentCount)
+
+        messagePanel.message = Message.fromAssistant("```kotlin\nprintln(\"Hi\")\n```")
+
+        assertEquals(2, messagePanel.componentCount)
+        assertTrue(messagePanel.parsed[0] is MessagePanel.Code)
+    }
+
     fun `test code block is rendered correctly`() {
         messagePanel.message = Message.fromAssistant("```kotlin\nprintln(\"Hello, World!\")\n```")
 


### PR DESCRIPTION
## Summary
- fix off-by-one error when replacing parsed content in MessagePanel
- test that component count stays correct when content type changes

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68402ee1f468832d9779a85de1a04c04