### PR TITLE
Fix code block markers in system prompt

### DIFF
--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
@@ -56,7 +56,7 @@ object OllamaService {
                         }
                         return prev;
                     }
-                    ´´´
+                    ```
 
                     This function initializes three pointers and iteratively reverses the direction of the next pointers.
 
@@ -66,25 +66,25 @@ object OllamaService {
 
                     [Code Context]:
 
-                    ´´´java
+                    ```java
                     public class Main {
                         public static void main(String[] args) {
                             String text = null;
                             System.out.println(text.length());
                         }
                     }
-                    ´´´
+                    ```
 
                     [Assistant]: The `NullPointerException` occurs because you're trying to call `length()` on a null object. You need to initialize `text` before using it:
 
-                    ´´´java
+                    ```java
                     public class Main {
                         public static void main(String[] args) {
                             String text = "Hello, World!";
                             System.out.println(text.length());
                         }
                     }
-                    ´´´
+                    ```
 
                     By assigning a value to `text`, you can safely call `length()` without triggering a `NullPointerException`.
 
@@ -94,22 +94,22 @@ object OllamaService {
 
                     [Code Context]:
 
-                    ´´´python
+                    ```python
                     def process_data(data):
                         result = []
                         for item in data:
                             if item not in result:
                                 result.append(item)
                         return result
-                    ´´´
+                    ```
 
                     [Assistant]: You can optimize the function by using a `set` to remove duplicates more efficiently:
 
-                    ´´´python
+                    ```python
                     def process_data(data):
                         # Use a set to remove duplicates and convert back to a list
                         return list(set(data))
-                    ´´´
+                    ```
 
                     This approach leverages the `set` data structure to eliminate duplicate items more efficiently than iterating through the list.
                     """.trimIndent()

--- a/src/test/kotlin/com/github/fmueller/jarvis/ai/OllamaServicePromptTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/ai/OllamaServicePromptTest.kt
@@ -1,0 +1,14 @@
+package com.github.fmueller.jarvis.ai
+
+import junit.framework.TestCase
+
+class OllamaServicePromptTest : TestCase() {
+
+    fun `test system prompt uses triple backticks`() {
+        val field = OllamaService::class.java.getDeclaredField("systemPrompt")
+        field.isAccessible = true
+        val prompt = field.get(OllamaService) as String
+        assertFalse("System prompt contains accent backticks", prompt.contains("´´´"))
+        assertTrue("System prompt should contain triple backticks", prompt.contains("```"))
+    }
+}


### PR DESCRIPTION
## Summary
- replace accent code block markers with triple backticks in system prompt

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684035d326fc832db0db1fe0b2db80cc