### PR TITLE
Fix Conversation listener cleanup

### DIFF
--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
@@ -114,7 +114,7 @@ class Conversation : Disposable {
     }
 
     override fun dispose() {
-        propertyChangeSupport.getPropertyChangeListeners("messages").forEach {
+        propertyChangeSupport.propertyChangeListeners.forEach {
             propertyChangeSupport.removePropertyChangeListener(it)
         }
     }

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/ConversationTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/ConversationTest.kt
@@ -1,0 +1,38 @@
+package com.github.fmueller.jarvis.conversation
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.beans.PropertyChangeListener
+import java.beans.PropertyChangeSupport
+
+class ConversationTest : BasePlatformTestCase() {
+
+    private lateinit var conversation: Conversation
+
+    override fun setUp() {
+        super.setUp()
+        conversation = Conversation()
+    }
+
+    override fun tearDown() {
+        conversation.dispose()
+        super.tearDown()
+    }
+
+    fun `test dispose removes property change listeners`() {
+        var called = false
+        val listener1 = PropertyChangeListener { called = true }
+        val listener2 = PropertyChangeListener { called = true }
+        conversation.addPropertyChangeListener(listener1)
+        conversation.addPropertyChangeListener(listener2)
+
+        val field = conversation.javaClass.getDeclaredField("propertyChangeSupport")
+        field.isAccessible = true
+        val pcs = field.get(conversation) as PropertyChangeSupport
+        assertEquals(2, pcs.propertyChangeListeners.size)
+
+        conversation.dispose()
+        conversation.addMessage(Message.fromAssistant("test"))
+        assertFalse(called)
+        assertEquals(0, pcs.propertyChangeListeners.size)
+    }
+}


### PR DESCRIPTION
## Summary
- remove all listeners in `Conversation.dispose`
- add tests to ensure listeners are cleared

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684035cc26c0832db33a3efe13b5d060