### PR TITLE
Add SlashCommand parser tests

### DIFF
--- a/src/test/kotlin/com/github/fmueller/jarvis/commands/SlashCommandParserTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/commands/SlashCommandParserTest.kt
@@ -1,0 +1,26 @@
+package com.github.fmueller.jarvis.commands
+
+import junit.framework.TestCase
+
+class SlashCommandParserTest : TestCase() {
+
+    fun `test parse help returns HelpCommand`() {
+        val command = SlashCommandParser.parse("/help")
+        assertTrue(command is HelpCommand)
+    }
+
+    fun `test parse new returns NewConversationCommand`() {
+        val command = SlashCommandParser.parse("/new")
+        assertTrue(command is NewConversationCommand)
+    }
+
+    fun `test parse plain returns PlainChatCommand`() {
+        val command = SlashCommandParser.parse("/plain hello")
+        assertTrue(command is PlainChatCommand)
+    }
+
+    fun `test parse model returns ModelCommand`() {
+        val command = SlashCommandParser.parse("/model llama3.1")
+        assertTrue(command is ModelCommand)
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for SlashCommandParser

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684035d6a4a4832d8e590dba19c5c6a6