### PR TITLE
Add AGENT instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,31 @@
-# AGENT instructions for jarvis repository
+# Guidelines for AI Agents
 
 ## Build and Test
-- Use `./gradlew test` to run the unit test suite.
+
+- Use `gradle build` to build the whole project.
+- Use `gradle check` to run all tests.
 - Ensure tests pass before committing code.
-- Use `./gradlew buildPlugin` if you need to assemble the plugin artifact.
 
 ## Code Style
+
 - Kotlin sources are in `src/main/kotlin` and tests in `src/test/kotlin`.
 - Use 4 spaces for indentation and keep lines under 120 characters.
 - End every file with a single newline.
+- Do not add dependencies. Only use the available libraries.
 - Keep public functions and classes documented with KDoc comments when adding new code.
+- Try to add unit tests for changes as you see fit.
 
 ## Documentation
-- Update `CHANGELOG.md` when adding or changing features.
+
 - Update `README.md` if user-facing behaviour changes.
+- Update `CHANGELOG.md` when adding or changing features.
 
 ## Commit Messages and PRs
-- Use concise commit messages describing what changed and why.
-- Summarize important modifications in the PR description.
 
+- Use concise commit messages describing what changed and why.
+- Use conventional commits, e.g.:
+    - `feat: add feature xyz`
+    - `refactor: move files to domain folder xyz`
+    - `docs: improve docs about data from report xyz`
+    - `chore: cleanup files`
+- Summarize important modifications in the PR description.


### PR DESCRIPTION
## Summary
- add AGENTS.md with instructions for building, testing, and documentation

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684886f8125c832d83eb7c57aae54fbc