### PR TITLE
Fix syntax highlighting in helper

### DIFF
--- a/src/test/kotlin/com/github/fmueller/jarvis/ui/SyntaxHighlightedCodeHelperTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/ui/SyntaxHighlightedCodeHelperTest.kt
@@ -1,0 +1,25 @@
+package com.github.fmueller.jarvis.ui
+
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class SyntaxHighlightedCodeHelperTest : BasePlatformTestCase() {
+
+    fun `test editor has syntax highlighting`() {
+        val helper = SyntaxHighlightedCodeHelper(project)
+        val editor = helper.getHighlightedEditor("kotlin", "fun foo() {}")
+        assertNotNull(editor)
+        editor as EditorEx
+
+        val defaultColor = EditorColorsManager.getInstance().globalScheme.defaultForeground
+        val index = editor.document.text.indexOf("fun")
+        val iterator = editor.highlighter.createIterator(index)
+        val keywordColor = iterator.textAttributes.foregroundColor
+
+        assertNotNull(keywordColor)
+        assertTrue(keywordColor != defaultColor)
+
+        helper.disposeEditor(editor)
+    }
+}


### PR DESCRIPTION
## Summary
- ensure code editors are created for a virtual file
- install a highlighter and restart the daemon
- add a test for colorized Kotlin code

## Testing
- `./gradlew test --no-daemon` *(fails: Path for java installation '/usr/lib/jvm/openjdk-21' does not contain a java executable)*

------
https://chatgpt.com/codex/tasks/task_e_684c3369c47c832da1bfd9fc8077cc2f