### PR TITLE
Add reasoning block rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - New `/copy` command copies the whole conversation to the clipboard
 - Automatic Ollama model download
+- Display reasoning from models using `<think>` blocks
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Available commands:
 - ```/copy``` - Copies the conversation to the clipboard
 - ```/model <modelName>``` - Changes the model to use (model name `default` is `qwen3:4b`)
 
+When using reasoning models with Ollama, Jarvis shows their internal thoughts in an expandable section at the top of each answer.
+
 ## License
 
 This project is licensed under the [MIT](LICENSE).

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/ConversationPanel.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/ConversationPanel.kt
@@ -74,7 +74,7 @@ class ConversationPanel(conversation: Conversation, private val project: Project
     private fun updateMessageInProgress(update: String) {
         if (update.isNotEmpty()) {
             if (updatePanel == null) {
-                updatePanel = MessagePanel(Message.fromAssistant(update), project)
+                updatePanel = MessagePanel(Message.fromAssistant(update), project, false)
                 Disposer.register(this, updatePanel!!)
                 panel.add(updatePanel)
             } else {
@@ -97,7 +97,7 @@ class ConversationPanel(conversation: Conversation, private val project: Project
         }
 
         if (messages.isNotEmpty()) {
-            val messagePanel = MessagePanel(messages.last(), project)
+            val messagePanel = MessagePanel(messages.last(), project, false)
             Disposer.register(this, messagePanel)
             panel.add(messagePanel)
         }

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.project.Project
+import com.intellij.ui.HideableDecorator
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.HTMLEditorKitBuilder
@@ -20,7 +21,6 @@ import org.jdesktop.swingx.VerticalLayout
 import java.awt.BorderLayout
 import java.awt.Font
 import java.util.regex.Pattern
-import com.intellij.ui.HideableDecorator
 import javax.swing.BorderFactory
 import javax.swing.JEditorPane
 import javax.swing.JPanel
@@ -305,24 +305,6 @@ class MessagePanel(initialMessage: Message, project: Project) : JPanel(), Dispos
             border = BorderFactory.createEmptyBorder(0, 0, 0, 0)
         }
         add(editorPane)
-    }
-
-    private fun addReasoning(markdown: String, isInProgress: Boolean = false) {
-        val outer = JPanel().apply { layout = BorderLayout() }
-        val content = JPanel().apply { layout = BorderLayout() }
-        val decorator = HideableDecorator(outer, "Reasoning", false)
-        decorator.setContentComponent(content)
-        decorator.setOn(isInProgress) // Open the decorator if reasoning is still in progress
-
-        val editorPane = JEditorPane().apply {
-            editorKit = HTMLEditorKitBuilder.simple()
-            text = markdownToHtml(markdown)
-            isEditable = false
-            background = outer.background
-            border = BorderFactory.createEmptyBorder(0, 0, 0, 0)
-        }
-        content.add(editorPane, BorderLayout.CENTER)
-        add(outer)
     }
 
     private fun addHighlightedCode(languageId: String, code: String) {

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
@@ -192,19 +192,20 @@ class MessagePanel(
             BorderFactory.createEmptyBorder(10, 10, 10, 10)
         )
 
-        add(JBLabel(
-            when (message.role) {
-                Role.ASSISTANT -> "Jarvis"
-                Role.USER -> "You"
-                Role.INFO -> "Info"
-            }
-        ).apply {
-            font = font.deriveFont(Font.BOLD)
-            border = BorderFactory.createEmptyBorder(0, 0, 0, 0)
-        })
-
-        // Only create reasoning panel if this is not already a reasoning panel
         if (!isReasoningPanel) {
+            add(
+                JBLabel(
+                    when (message.role) {
+                        Role.ASSISTANT -> "Jarvis"
+                        Role.USER -> "You"
+                        Role.INFO -> "Info"
+                    }
+                ).apply {
+                    font = font.deriveFont(Font.BOLD)
+                    border = BorderFactory.createEmptyBorder(0, 0, 0, 0)
+                }
+            )
+
             val outerPanel = JPanel().apply { layout = BorderLayout() }
             val contentPanel = JPanel().apply { layout = BorderLayout() }
             reasoningPanel = outerPanel

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
@@ -214,7 +214,7 @@ class MessagePanel(
 
             reasoningMessagePanel = MessagePanel(Message.fromAssistant(""), project, true).apply {
                 background = outerPanel.background
-                border = BorderFactory.createEmptyBorder(0, 0, 0, 0)
+                border = BorderFactory.createEmptyBorder(0, 15, 0, 10)
             }
             contentPanel.add(reasoningMessagePanel, BorderLayout.CENTER)
             add(outerPanel)

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
@@ -9,7 +9,7 @@ class MessagePanelTest : BasePlatformTestCase() {
 
     override fun setUp() {
         super.setUp()
-        messagePanel = MessagePanel(Message.fromAssistant("Hello, I am Jarvis."), project)
+        messagePanel = MessagePanel(Message.fromAssistant("Hello, I am Jarvis."), project, false)
     }
 
     override fun tearDown() {
@@ -100,7 +100,7 @@ class MessagePanelTest : BasePlatformTestCase() {
     }
 
     fun `test info message label`() {
-        val panel = MessagePanel(Message.info("Downloading"), project)
+        val panel = MessagePanel(Message.info("Downloading"), project, false)
         val label = panel.getComponent(0) as JBLabel
         assertEquals("Info", label.text)
     }
@@ -109,6 +109,6 @@ class MessagePanelTest : BasePlatformTestCase() {
         messagePanel.message = Message.fromAssistant("<think>Reason</think>Hello")
 
         assertEquals(1, messagePanel.parsed.size)
-        assertTrue(messagePanel.reasoningEditorPane?.text?.contains("Reason") ?: false)
+        assertTrue(messagePanel.reasoningMessagePanel?.message?.content?.contains("Reason") ?: false)
     }
 }

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
@@ -2,6 +2,8 @@ package com.github.fmueller.jarvis.conversation
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.ui.components.JBLabel
+import javax.swing.JButton
+import javax.swing.JPanel
 
 class MessagePanelTest : BasePlatformTestCase() {
 
@@ -110,5 +112,40 @@ class MessagePanelTest : BasePlatformTestCase() {
 
         assertEquals(1, messagePanel.parsed.size)
         assertTrue(messagePanel.reasoningMessagePanel?.message?.content?.contains("Reason") ?: false)
+    }
+
+    fun `test reasoning panel toggle functionality`() {
+        // Set a message with reasoning to make the reasoning panel visible
+        messagePanel.message = Message.fromAssistant("<think>Reasoning content</think>Hello")
+
+        // Get the reasoning panel components using reflection
+        val reasoningPanelField = MessagePanel::class.java.getDeclaredField("reasoningPanel")
+        reasoningPanelField.isAccessible = true
+        val reasoningPanel = reasoningPanelField.get(messagePanel) as JPanel
+
+        val reasoningContentPanelField = MessagePanel::class.java.getDeclaredField("reasoningContentPanel")
+        reasoningContentPanelField.isAccessible = true
+        val reasoningContentPanel = reasoningContentPanelField.get(messagePanel) as JPanel
+
+        val reasoningHeaderButtonField = MessagePanel::class.java.getDeclaredField("reasoningHeaderButton")
+        reasoningHeaderButtonField.isAccessible = true
+        val reasoningHeaderButton = reasoningHeaderButtonField.get(messagePanel) as JButton
+
+        // Verify initial state
+        assertTrue(reasoningPanel.isVisible)
+        assertFalse(reasoningContentPanel.isVisible)
+        assertEquals("Reasoning", reasoningHeaderButton.text)
+
+        // Click the button to expand the panel
+        reasoningHeaderButton.doClick()
+
+        // Verify expanded state
+        assertTrue(reasoningContentPanel.isVisible)
+
+        // Click the button again to collapse the panel
+        reasoningHeaderButton.doClick()
+
+        // Verify collapsed state
+        assertFalse(reasoningContentPanel.isVisible)
     }
 }

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
@@ -108,10 +108,7 @@ class MessagePanelTest : BasePlatformTestCase() {
     fun `test reasoning block is parsed`() {
         messagePanel.message = Message.fromAssistant("<think>Reason</think>Hello")
 
-        assertEquals(2, messagePanel.parsed.size)
-        assertTrue(messagePanel.parsed[0] is MessagePanel.Reasoning)
-        val reasoning = messagePanel.parsed[0] as MessagePanel.Reasoning
-        assertEquals("Reason", reasoning.markdown)
-        assertTrue(messagePanel.parsed[1] is MessagePanel.Content)
+        assertEquals(1, messagePanel.parsed.size)
+        assertTrue(messagePanel.reasoningEditorPane?.text?.contains("Reason") ?: false)
     }
 }

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
@@ -104,4 +104,14 @@ class MessagePanelTest : BasePlatformTestCase() {
         val label = panel.getComponent(0) as JBLabel
         assertEquals("Info", label.text)
     }
+
+    fun `test reasoning block is parsed`() {
+        messagePanel.message = Message.fromAssistant("<think>Reason</think>Hello")
+
+        assertEquals(2, messagePanel.parsed.size)
+        assertTrue(messagePanel.parsed[0] is MessagePanel.Reasoning)
+        val reasoning = messagePanel.parsed[0] as MessagePanel.Reasoning
+        assertEquals("Reason", reasoning.markdown)
+        assertTrue(messagePanel.parsed[1] is MessagePanel.Content)
+    }
 }


### PR DESCRIPTION
## Summary
- support reasoning models from Ollama by parsing `<think>` blocks
- render reasoning in a collapsible accordion
- document reasoning display
- update changelog
- test reasoning parsing in `MessagePanel`

## Testing
- `gradle build`
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_684e97a7eaa8832d8dbb28e57681498d