### PR TITLE
Fix copy command for plain messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Allow `/model` command to accept any Ollama model
 - Set `qwen3:4b` as the default model
+- `/copy` ignores code context for `/plain` messages
 
 ## [1.6.0] - 2024-11-27
 

--- a/src/main/kotlin/com/github/fmueller/jarvis/commands/CopyCommand.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/commands/CopyCommand.kt
@@ -27,9 +27,12 @@ class CopyCommand : SlashCommand {
         builder.appendLine()
         conversation.messages.forEach { message ->
             if (message.role == Role.USER) {
-                builder.appendLine("[User]: ${message.contentWithClosedTrailingCodeBlock().removePrefix("/plain ")}")
+                builder.appendLine(
+                    "[User]: " +
+                        message.contentWithClosedTrailingCodeBlock().removePrefix("/plain ")
+                )
                 val code = message.codeContext?.selected
-                if (code != null) {
+                if (code != null && !message.content.startsWith("/plain ")) {
                     builder.appendLine("[Code Context]:")
                     builder.appendLine(formatCode(code))
                 }

--- a/src/test/kotlin/com/github/fmueller/jarvis/commands/CopyCommandTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/commands/CopyCommandTest.kt
@@ -32,4 +32,21 @@ class CopyCommandTest : TestCase() {
         assertFalse(prompt.contains("Code Context"))
         assertFalse(prompt.contains("No code context"))
     }
+
+    fun `test buildPrompt omits code for plain message`() {
+        val conversation = Conversation()
+        conversation.addMessage(Message.fromAssistant("Hi"))
+        conversation.addMessage(
+            Message(
+                Role.USER,
+                "/plain Explain",
+                CodeContext("project", Code("println()", Language.ANY))
+            )
+        )
+
+        val prompt = CopyCommand().buildPrompt(conversation)
+
+        assertFalse(prompt.contains("Code Context"))
+        assertFalse(prompt.contains("println()"))
+    }
 }


### PR DESCRIPTION
## Summary
- don't include code context in copy output when message sent with `/plain`
- add a regression test for plain message handling
- document the change in the changelog

## Testing
- `gradle build`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_684eaeacac90832d98d32294fd6d2736