### PR TITLE
Refine copy command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Allow `/model` command to accept any Ollama model
 - Set `qwen3:4b` as the default model
+- `/copy` no longer includes model, help, copy or host commands nor info messages
 
 ### Fixed
 

--- a/src/main/kotlin/com/github/fmueller/jarvis/commands/CopyCommand.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/commands/CopyCommand.kt
@@ -26,7 +26,17 @@ class CopyCommand : SlashCommand {
         )
         builder.appendLine()
         conversation.messages.forEach { message ->
+            if (message.role == Role.INFO) return@forEach
+
             if (message.role == Role.USER) {
+                val content = message.content.trim()
+                val isIgnoredCommand = content == "/copy" ||
+                    content == "/help" ||
+                    content == "/?" ||
+                    content.startsWith("/model ") ||
+                    content.startsWith("/host ")
+                if (isIgnoredCommand) return@forEach
+
                 builder.appendLine(
                     "[User]: " +
                         message.contentWithClosedTrailingCodeBlock().removePrefix("/plain ")
@@ -37,9 +47,11 @@ class CopyCommand : SlashCommand {
                     builder.appendLine(formatCode(code))
                 }
             }
-            if (message.role == Role.ASSISTANT) {
+
+            if (message.role == Role.ASSISTANT && !message.isHelpMessage()) {
                 builder.appendLine("[Assistant]: ${message.contentWithClosedTrailingCodeBlock()}")
             }
+
             builder.appendLine()
         }
         return builder.toString().trimEnd()

--- a/src/test/kotlin/com/github/fmueller/jarvis/commands/CopyCommandTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/commands/CopyCommandTest.kt
@@ -49,4 +49,29 @@ class CopyCommandTest : TestCase() {
         assertFalse(prompt.contains("Code Context"))
         assertFalse(prompt.contains("println()"))
     }
+
+    fun `test buildPrompt ignores commands and info messages`() {
+        val conversation = Conversation()
+        conversation.addMessage(Message.fromAssistant("Hi"))
+        conversation.addMessage(Message(Role.USER, "/model llama"))
+        conversation.addMessage(Message.info("Model changed"))
+        conversation.addMessage(Message(Role.USER, "/host http://1.2.3.4"))
+        conversation.addMessage(Message.info("Host changed"))
+        conversation.addMessage(Message(Role.USER, "/help"))
+        conversation.addMessage(Message.HELP_MESSAGE)
+        conversation.addMessage(Message(Role.USER, "/copy"))
+        conversation.addMessage(Message.info("Conversation copied"))
+        conversation.addMessage(Message(Role.USER, "Explain"))
+        conversation.addMessage(Message.fromAssistant("Sure"))
+
+        val prompt = CopyCommand().buildPrompt(conversation)
+
+        assertTrue(prompt.contains("Explain"))
+        assertTrue(prompt.contains("Sure"))
+        assertFalse(prompt.contains("Model changed"))
+        assertFalse(prompt.contains("/model"))
+        assertFalse(prompt.contains("/host"))
+        assertFalse(prompt.contains("/help"))
+        assertFalse(prompt.contains("Conversation copied"))
+    }
 }


### PR DESCRIPTION
## Summary
- ignore commands and info messages when building clipboard text
- test CopyCommand ignores commands and info messages
- document copy command behaviour change

## Testing
- `gradle build --no-daemon`
- `gradle check --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6851ab886980832d9ce682542d53ef74