### PR TITLE
fix parsing of indented code fences

### DIFF
--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
@@ -33,7 +33,7 @@ class MessagePanel(
 ) : JPanel(), Disposable {
 
     private companion object {
-        private val codeBlockPattern = Pattern.compile("```(\\w+)?\\n(.*?)\\n```", Pattern.DOTALL)
+        private val codeBlockPattern = Pattern.compile("```(\\w+)?\\n(.*?)\\n\\s*```", Pattern.DOTALL)
         private val assistantBgColor = { UIUtil.getPanelBackground() }
         private val userBgColor = { UIUtil.getTextFieldBackground() }
     }

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
@@ -70,6 +70,29 @@ class MessagePanelTest : BasePlatformTestCase() {
         assertEquals("println(\"Hello, World!\")", parsedCode.content)
     }
 
+    fun `test indented closing code block is rendered correctly`() {
+        messagePanel.message = Message.fromAssistant("```kotlin\nprintln(\"Hello, World!\")\n    ```")
+
+        assertEquals(1, messagePanel.parsed.size)
+        assertTrue(messagePanel.parsed[0] is MessagePanel.Code)
+
+        val parsedCode = messagePanel.parsed[0] as MessagePanel.Code
+        assertEquals("kotlin", parsedCode.languageId)
+        assertEquals("println(\"Hello, World!\")", parsedCode.content)
+    }
+
+    fun `test code block without preceding blank line is parsed correctly`() {
+        messagePanel.message = Message.fromAssistant("Here is some code:\n```kotlin\nprintln(\"Hello, World!\")\n```")
+
+        assertEquals(2, messagePanel.parsed.size)
+        assertTrue(messagePanel.parsed[0] is MessagePanel.Content)
+        assertTrue(messagePanel.parsed[1] is MessagePanel.Code)
+
+        val parsedCode = messagePanel.parsed[1] as MessagePanel.Code
+        assertEquals("kotlin", parsedCode.languageId)
+        assertEquals("println(\"Hello, World!\")", parsedCode.content)
+    }
+
     fun `test empty code block is rendered correctly as code block`() {
         messagePanel.message = Message.fromAssistant("```kotlin\n\n```")
 


### PR DESCRIPTION
## Summary
- handle closing code blocks that have indentation
- add regression test for indented closing code fences
- test code blocks parsing when no blank line precedes the fence

## Testing
- `gradle build --no-daemon`
- `gradle check --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68542e12ee04832dbdbb4457b3f7fa9f