### PR TITLE
Add cancel chat option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Handle malformed code blocks using two backticks
+- Stop ongoing chat requests with a new stop button
 
 ## [1.7.1] - 2025-06-18
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Available commands:
 
 When using reasoning models with Ollama, Jarvis shows their internal thoughts in an expandable section at the top of each answer.
 
+To cancel an ongoing request, click the stop button next to the input field.
+
 ## License
 
 This project is licensed under the [MIT](LICENSE).

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
@@ -4,6 +4,9 @@ import com.github.fmueller.jarvis.commands.SlashCommandParser
 import com.intellij.lang.Language
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import java.beans.PropertyChangeListener
 import java.beans.PropertyChangeSupport
 import java.time.LocalDateTime
@@ -103,12 +106,38 @@ class Conversation : Disposable {
     private var _messages = mutableListOf<Message>()
     val messages get() = _messages.toList()
 
+    @Volatile
+    private var chatJob: Job? = null
+
     private val _messageBeingGenerated = StringBuilder()
 
     private val propertyChangeSupport = PropertyChangeSupport(this)
 
     init {
         addMessage(greetingMessage())
+    }
+
+    fun isChatInProgress(): Boolean = chatJob?.isActive == true
+
+    fun cancelChat() {
+        chatJob?.cancel()
+    }
+
+    fun startChat(message: Message, scope: CoroutineScope): Job {
+        chatJob?.cancel()
+
+        val job = scope.launch {
+            try {
+                chat(message)
+            } finally {
+                chatJob = null
+                propertyChangeSupport.firePropertyChange("chatInProgress", true, false)
+            }
+        }
+
+        chatJob = job
+        propertyChangeSupport.firePropertyChange("chatInProgress", false, true)
+        return job
     }
 
     suspend fun chat(message: Message): Conversation {


### PR DESCRIPTION
## Summary
- support chat cancellation in `Conversation`
- show a stop button in the conversation window to cancel the current request
- document the stop button feature
- mention stop button in the changelog

## Testing
- `gradle build`
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_685c483be104832dbafb4c4a46527281