### PR TITLE
Add cancel chat option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Handle malformed code blocks using two backticks
+- Stop ongoing chat requests with a new stop button
 
 ## [1.7.1] - 2025-06-18
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Available commands:
 
 When using reasoning models with Ollama, Jarvis shows their internal thoughts in an expandable section at the top of each answer.
 
+To cancel an ongoing request, click the stop button next to the input field.
+
 ## License
 
 This project is licensed under the [MIT](LICENSE).

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/CompletableFutureExtensions.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/CompletableFutureExtensions.kt
@@ -1,0 +1,17 @@
+package com.github.fmueller.jarvis.ai
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.concurrent.CompletableFuture
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+internal suspend fun <T> CompletableFuture<T>.awaitCancellable(): T = suspendCancellableCoroutine { cont ->
+    whenComplete { result, error ->
+        if (error == null) {
+            cont.resume(result)
+        } else {
+            cont.resumeWithException(error)
+        }
+    }
+    cont.invokeOnCancellation { this.cancel(true) }
+}

--- a/src/test/kotlin/com/github/fmueller/jarvis/ai/CompletableFutureAwaitTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/ai/CompletableFutureAwaitTest.kt
@@ -1,0 +1,25 @@
+package com.github.fmueller.jarvis.ai
+
+import junit.framework.TestCase
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.CompletableFuture
+
+class CompletableFutureAwaitTest : TestCase() {
+    fun `test awaitCancellable cancels future`() = runBlocking {
+        val future = CompletableFuture<String>()
+        val job: Job = launch {
+            try {
+                future.awaitCancellable()
+            } catch (_: Exception) {
+                // ignore
+            }
+        }
+        delay(100)
+        job.cancelAndJoin()
+        assertTrue(future.isCancelled)
+    }
+}

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/ConversationCancellationTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/ConversationCancellationTest.kt
@@ -1,0 +1,64 @@
+package com.github.fmueller.jarvis.conversation
+
+import com.github.fmueller.jarvis.ai.OllamaService
+import com.sun.net.httpserver.HttpServer
+import junit.framework.TestCase
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+
+class ConversationCancellationTest : TestCase() {
+
+    private lateinit var server: HttpServer
+    override fun setUp() {
+        super.setUp()
+        val port = findAvailablePort()
+        server = HttpServer.create(InetSocketAddress(port), 0)
+        server.createContext("/") { exchange ->
+            exchange.sendResponseHeaders(200, -1)
+            exchange.close()
+        }
+        server.createContext("/api/tags") { exchange ->
+            val body = """{"models":[{"name":"${OllamaService.modelName}"}]}"""
+            exchange.sendResponseHeaders(200, body.toByteArray().size.toLong())
+            exchange.responseBody.use { it.write(body.toByteArray()) }
+        }
+        server.createContext("/api/generate") { exchange ->
+            exchange.sendResponseHeaders(200, 0)
+            val out = exchange.responseBody
+            try {
+                out.write("{\"response\":\"hello\",\"done\":false}".toByteArray())
+                out.flush()
+                Thread.sleep(2000)
+                out.write("{\"done\":true}".toByteArray())
+            } catch (_: IOException) {
+            } finally {
+                out.close()
+            }
+        }
+        server.start()
+        OllamaService.host = "http://localhost:$port"
+    }
+
+    override fun tearDown() {
+        server.stop(0)
+        super.tearDown()
+    }
+
+    fun `test cancel chat aborts request`() = runBlocking {
+        val conversation = Conversation()
+        val job = conversation.startChat(Message(Role.USER, "hi"), this)
+        delay(200)
+        conversation.cancelChat()
+        job.join()
+
+        assertFalse(conversation.isChatInProgress())
+        assertEquals(2, conversation.messages.size)
+    }
+
+    private fun findAvailablePort(): Int {
+        return ServerSocket(0).use { it.localPort }
+    }
+}


### PR DESCRIPTION
## Summary
- support chat cancellation in `Conversation`
- stop ongoing request in `OllamaService` using coroutines
- add coroutine-based await extension
- add tests for cancellation

## Testing
- `gradle build`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_685c483be104832dbafb4c4a46527281