### PR TITLE
feat: add interruptable messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(libs.flexmark)
     implementation("dev.langchain4j:langchain4j:1.1.0")
     implementation("dev.langchain4j:langchain4j-ollama:1.1.0-rc1")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
     testImplementation(libs.junit)
     testImplementation(libs.opentest4j)

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
@@ -116,7 +116,7 @@ object OllamaService {
                     This approach leverages the `set` data structure to eliminate duplicate items more efficiently than iterating through the list.
                     """.trimIndent()
 
-    private var currentHttpClient: CancellableHttpClient? = null
+    private var currentInferenceClient: CancellableHttpClient? = null
 
     private val client = java.net.http.HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(2))
@@ -323,12 +323,12 @@ object OllamaService {
 
     private fun createAiService(): Assistant {
         cancelCurrentRequest()
-        currentHttpClient = CancellableHttpClient()
+        currentInferenceClient = CancellableHttpClient()
         return AiServices
             .builder(Assistant::class.java)
             .streamingChatModel(
                 OllamaStreamingChatModel.builder()
-                    .httpClientBuilder(currentHttpClient!!.getHttpClientBuilder())
+                    .httpClientBuilder(currentInferenceClient!!.getHttpClientBuilder())
                     .timeout(Duration.ofMinutes(5))
                     .baseUrl(host)
                     .modelName(modelName)
@@ -344,6 +344,6 @@ object OllamaService {
     }
 
     private fun cancelCurrentRequest() {
-        currentHttpClient?.cancel()
+        currentInferenceClient?.cancel()
     }
 }

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
@@ -1,15 +1,10 @@
 package com.github.fmueller.jarvis.ai
 
+import com.github.fmueller.jarvis.ai.http.CancellableHttpClient
 import com.github.fmueller.jarvis.conversation.CodeContext
 import com.github.fmueller.jarvis.conversation.Conversation
 import com.github.fmueller.jarvis.conversation.Message
 import com.intellij.lang.Language
-import dev.langchain4j.http.client.HttpClient
-import dev.langchain4j.http.client.HttpClientBuilder
-import dev.langchain4j.http.client.HttpRequest
-import dev.langchain4j.http.client.SuccessfulHttpResponse
-import dev.langchain4j.http.client.sse.ServerSentEventListener
-import dev.langchain4j.http.client.sse.ServerSentEventParser
 import dev.langchain4j.memory.chat.TokenWindowChatMemory
 import dev.langchain4j.model.ollama.OllamaStreamingChatModel
 import dev.langchain4j.service.AiServices
@@ -19,14 +14,11 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import okhttp3.*
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.RequestBody.Companion.toRequestBody
 import org.jetbrains.annotations.VisibleForTesting
-import java.io.IOException
 import java.net.URI
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.time.Duration
-import java.util.concurrent.TimeUnit
 
 object OllamaService {
 
@@ -260,12 +252,12 @@ object OllamaService {
 
     fun isAvailable(): Boolean {
         return try {
-            val request = java.net.http.HttpRequest.newBuilder()
+            val request = HttpRequest.newBuilder()
                 .uri(URI.create(host))
                 .timeout(Duration.ofSeconds(2))
                 .build()
 
-            val response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
             response.statusCode() == 200
         } catch (e: Exception) {
             false
@@ -275,12 +267,12 @@ object OllamaService {
     @VisibleForTesting
     fun isModelAvailable(): Boolean {
         return try {
-            val request = java.net.http.HttpRequest.newBuilder()
+            val request = HttpRequest.newBuilder()
                 .uri(URI.create("$host/api/tags"))
                 .timeout(Duration.ofSeconds(2))
                 .build()
 
-            val response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
             if (response.statusCode() != 200) return false
             val json = Json.parseToJsonElement(response.body())
             val models = json.jsonObject["models"]?.jsonArray ?: return false
@@ -295,14 +287,14 @@ object OllamaService {
 
     private fun pullModel(): String? {
         return try {
-            val request = java.net.http.HttpRequest.newBuilder()
+            val request = HttpRequest.newBuilder()
                 .uri(URI.create("$host/api/pull"))
                 .timeout(Duration.ofSeconds(2))
                 .header("Content-Type", "application/json")
-                .POST(java.net.http.HttpRequest.BodyPublishers.ofString("{\"name\":\"$modelName\"}"))
+                .POST(HttpRequest.BodyPublishers.ofString("{\"name\":\"$modelName\"}"))
                 .build()
 
-            val response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
             val body = response.body()
             val error = body.lineSequence()
                 .mapNotNull { runCatching {
@@ -321,7 +313,9 @@ object OllamaService {
     }
 
     private suspend fun ensureModelAvailable(conversation: Conversation): Boolean {
-        if (isModelAvailable()) return true
+        if (isModelAvailable()) {
+            return true
+        }
 
         conversation.addMessage(Message.info("Downloading model..."))
         val pullError = pullModel()
@@ -367,160 +361,5 @@ object OllamaService {
 
     private fun cancelCurrentRequest() {
         currentHttpClient?.cancel()
-    }
-
-    /**
-    * Wrapper for HttpClient that can be canceled
-    */
-    private class CancellableHttpClient {
-
-        @Volatile
-        private var currentCall: Call? = null
-
-        fun getHttpClientBuilder(): HttpClientBuilder {
-            return OkHttpClientBuilder(this)
-        }
-
-        fun setCurrentCall(call: Call) {
-            currentCall?.cancel()
-            currentCall = call
-        }
-
-        fun cancel() {
-            currentCall?.cancel()
-            currentCall = null
-        }
-    }
-
-    private class OkHttpClientBuilder(private val cancellableHttpClient: CancellableHttpClient) : HttpClientBuilder {
-
-        private var connectTimeout: Duration = Duration.ofSeconds(30)
-        private var readTimeout: Duration = Duration.ofSeconds(5)
-
-        override fun connectTimeout(): Duration = connectTimeout
-
-        override fun connectTimeout(timeout: Duration?): HttpClientBuilder {
-            timeout?.let { this.connectTimeout = it }
-            return this
-        }
-
-        override fun readTimeout(): Duration = readTimeout
-
-        override fun readTimeout(timeout: Duration?): HttpClientBuilder {
-            timeout?.let { this.readTimeout = it }
-            return this
-        }
-
-        override fun build(): HttpClient? {
-            val okHttpClient = OkHttpClient.Builder()
-                .connectTimeout(connectTimeout.toMillis(), TimeUnit.MILLISECONDS)
-                .readTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
-                .writeTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
-                .build()
-
-            return OkHttpClientAdapter(okHttpClient, cancellableHttpClient)
-        }
-    }
-
-    private class OkHttpClientAdapter(
-        private val okHttpClient: OkHttpClient,
-        private val cancellableHttpClient: CancellableHttpClient
-    ) : HttpClient {
-
-        override fun execute(request: HttpRequest): SuccessfulHttpResponse {
-            val call = okHttpClient.newCall(convertToOkHttpRequest(request))
-            cancellableHttpClient.setCurrentCall(call)
-
-            return try {
-                val response = call.execute()
-                convertToLangChain4jResponse(response)
-            } catch (e: IOException) {
-                throw RuntimeException("HTTP request failed", e)
-            }
-        }
-
-        override fun execute(
-            request: HttpRequest?,
-            parser: ServerSentEventParser?,
-            listener: ServerSentEventListener?
-        ) {
-            if (request == null || parser == null || listener == null) {
-                throw IllegalArgumentException("Request, parser, and listener cannot be null")
-            }
-
-            val call = okHttpClient.newCall(convertToOkHttpRequest(request))
-            cancellableHttpClient.setCurrentCall(call)
-
-            try {
-                call.enqueue(object : Callback {
-                    override fun onFailure(call: Call, e: IOException) {
-                        listener.onError(RuntimeException("SSE request failed", e))
-                    }
-
-                    override fun onResponse(call: Call, response: Response) {
-                        if (!response.isSuccessful) {
-                            listener.onError(RuntimeException("SSE request failed with status: ${response.code}"))
-                            return
-                        }
-
-                        response.body?.let { responseBody ->
-                            try {
-                                responseBody.byteStream().use { inputStream ->
-                                    // The parser will read from the InputStream and call the listener methods directly
-                                    parser.parse(inputStream, listener)
-                                }
-                            } catch (e: Exception) {
-                                if (!call.isCanceled()) {
-                                    listener.onError(RuntimeException("Error reading SSE stream", e))
-                                }
-                            }
-                        } ?: run {
-                            listener.onError(RuntimeException("No response body received"))
-                        }
-                    }
-                })
-            } catch (e: Exception) {
-                listener.onError(RuntimeException("Failed to execute SSE request", e))
-            }
-        }
-
-        private fun convertToOkHttpRequest(request: HttpRequest): Request {
-            val builder = Request.Builder().url(request.url())
-            request.headers().forEach { (name, values) ->
-                values.forEach { value ->
-                    builder.addHeader(name, value)
-                }
-            }
-
-            when (request.method()) {
-                dev.langchain4j.http.client.HttpMethod.GET -> builder.get()
-                dev.langchain4j.http.client.HttpMethod.POST -> {
-                    val body = request.body()?.let { bodyContent ->
-                        val contentType = request.headers()["Content-Type"]?.firstOrNull()
-                            ?: "application/json"
-                        bodyContent.toRequestBody(contentType.toMediaType())
-                    } ?: "".toRequestBody()
-                    builder.post(body)
-                }
-                dev.langchain4j.http.client.HttpMethod.DELETE -> builder.delete()
-                else -> throw IllegalArgumentException("Unsupported HTTP method: ${request.method()}")
-            }
-
-            return builder.build()
-        }
-
-        private fun convertToLangChain4jResponse(response: Response): SuccessfulHttpResponse {
-            val body = response.body?.string() ?: ""
-            val headers = mutableMapOf<String, List<String>>()
-            response.headers.forEach { (name, value) ->
-                headers[name] = headers.getOrDefault(name, emptyList()) + value
-            }
-
-            return SuccessfulHttpResponse.builder()
-                .statusCode(response.code)
-                .headers(headers)
-                .body(body)
-                .build()
-        }
     }
 }

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
@@ -205,15 +205,6 @@ object OllamaService {
 
                 continuation.invokeOnCancellation {
                     cancelCurrentRequest()
-                    runCatching {
-                        val cancellationMessage = StringBuilder()
-                            .appendLine()
-                            .appendLine()
-                            .append("*Request cancelled by user.*")
-                            .toString()
-                        responseInFlight.append(cancellationMessage)
-                        conversation.addToMessageBeingGenerated(cancellationMessage)
-                    }
                 }
 
                 tokenStream.start()

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/http/CancellableHttpClient.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/http/CancellableHttpClient.kt
@@ -1,0 +1,24 @@
+package com.github.fmueller.jarvis.ai.http
+
+import dev.langchain4j.http.client.HttpClientBuilder
+import okhttp3.Call
+
+class CancellableHttpClient {
+
+    @Volatile
+    private var currentCall: Call? = null
+
+    fun getHttpClientBuilder(): HttpClientBuilder {
+        return OkHttpClientBuilder(this)
+    }
+
+    fun setCurrentCall(call: Call) {
+        currentCall?.cancel()
+        currentCall = call
+    }
+
+    fun cancel() {
+        currentCall?.cancel()
+        currentCall = null
+    }
+}

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/http/OkHttpClientAdapter.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/http/OkHttpClientAdapter.kt
@@ -1,0 +1,120 @@
+package com.github.fmueller.jarvis.ai.http
+
+import dev.langchain4j.http.client.HttpClient
+import dev.langchain4j.http.client.HttpRequest
+import dev.langchain4j.http.client.SuccessfulHttpResponse
+import dev.langchain4j.http.client.sse.ServerSentEventListener
+import dev.langchain4j.http.client.sse.ServerSentEventParser
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import java.io.IOException
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.firstOrNull
+
+class OkHttpClientAdapter(
+    private val okHttpClient: OkHttpClient,
+    private val cancellableHttpClient: CancellableHttpClient
+) : HttpClient {
+
+    override fun execute(request: HttpRequest): SuccessfulHttpResponse {
+        val call = okHttpClient.newCall(convertToOkHttpRequest(request))
+        cancellableHttpClient.setCurrentCall(call)
+
+        return try {
+            val response = call.execute()
+            convertToLangChain4jResponse(response)
+        } catch (e: IOException) {
+            throw RuntimeException("HTTP request failed", e)
+        }
+    }
+
+    override fun execute(
+        request: HttpRequest?,
+        parser: ServerSentEventParser?,
+        listener: ServerSentEventListener?
+    ) {
+        if (request == null || parser == null || listener == null) {
+            throw IllegalArgumentException("Request, parser, and listener cannot be null")
+        }
+
+        val call = okHttpClient.newCall(convertToOkHttpRequest(request))
+        cancellableHttpClient.setCurrentCall(call)
+
+        try {
+            call.enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    listener.onError(RuntimeException("SSE request failed", e))
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    if (!response.isSuccessful) {
+                        listener.onError(RuntimeException("SSE request failed with status: ${response.code}"))
+                        return
+                    }
+
+                    response.body?.let { responseBody ->
+                        try {
+                            responseBody.byteStream().use { inputStream ->
+                                // The parser will read from the InputStream and call the listener methods directly
+                                parser.parse(inputStream, listener)
+                            }
+                        } catch (e: Exception) {
+                            if (!call.isCanceled()) {
+                                listener.onError(RuntimeException("Error reading SSE stream", e))
+                            }
+                        }
+                    } ?: run {
+                        listener.onError(RuntimeException("No response body received"))
+                    }
+                }
+            })
+        } catch (e: Exception) {
+            listener.onError(RuntimeException("Failed to execute SSE request", e))
+        }
+    }
+
+    private fun convertToOkHttpRequest(request: HttpRequest): Request {
+        val builder = Request.Builder().url(request.url())
+        request.headers().forEach { (name, values) ->
+            values.forEach { value ->
+                builder.addHeader(name, value)
+            }
+        }
+
+        when (request.method()) {
+            dev.langchain4j.http.client.HttpMethod.GET -> builder.get()
+            dev.langchain4j.http.client.HttpMethod.POST -> {
+                val body = request.body()?.let { bodyContent ->
+                    val contentType = request.headers()["Content-Type"]?.firstOrNull()
+                        ?: "application/json"
+                    bodyContent.toRequestBody(contentType.toMediaType())
+                } ?: "".toRequestBody()
+                builder.post(body)
+            }
+            dev.langchain4j.http.client.HttpMethod.DELETE -> builder.delete()
+            else -> throw IllegalArgumentException("Unsupported HTTP method: ${request.method()}")
+        }
+
+        return builder.build()
+    }
+
+    private fun convertToLangChain4jResponse(response: Response): SuccessfulHttpResponse {
+        val body = response.body?.string() ?: ""
+        val headers = mutableMapOf<String, List<String>>()
+        response.headers.forEach { (name, value) ->
+            headers[name] = headers.getOrDefault(name, emptyList()) + value
+        }
+
+        return SuccessfulHttpResponse.builder()
+            .statusCode(response.code)
+            .headers(headers)
+            .body(body)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/http/OkHttpClientBuilder.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/http/OkHttpClientBuilder.kt
@@ -1,0 +1,37 @@
+package com.github.fmueller.jarvis.ai.http
+
+import dev.langchain4j.http.client.HttpClient
+import dev.langchain4j.http.client.HttpClientBuilder
+import okhttp3.OkHttpClient
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+class OkHttpClientBuilder(private val cancellableHttpClient: CancellableHttpClient) : HttpClientBuilder {
+
+    private var connectTimeout: Duration = Duration.ofSeconds(30)
+    private var readTimeout: Duration = Duration.ofSeconds(5)
+
+    override fun connectTimeout(): Duration = connectTimeout
+
+    override fun connectTimeout(timeout: Duration?): HttpClientBuilder {
+        timeout?.let { this.connectTimeout = it }
+        return this
+    }
+
+    override fun readTimeout(): Duration = readTimeout
+
+    override fun readTimeout(timeout: Duration?): HttpClientBuilder {
+        timeout?.let { this.readTimeout = it }
+        return this
+    }
+
+    override fun build(): HttpClient? {
+        val okHttpClient = OkHttpClient.Builder()
+            .connectTimeout(connectTimeout.toMillis(), TimeUnit.MILLISECONDS)
+            .readTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
+            .writeTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
+            .build()
+
+        return OkHttpClientAdapter(okHttpClient, cancellableHttpClient)
+    }
+}

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
@@ -118,6 +118,7 @@ class Conversation : Disposable {
     fun cancelCurrentChat() {
         currentChatJob?.cancel()
         currentChatJob = null
+        clearMessageBeingGenerated()
     }
 
     private val _messageBeingGenerated = StringBuilder()

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
@@ -127,29 +127,6 @@ class Conversation : Disposable {
     init {
         addMessage(greetingMessage())
     }
-/*
-    suspend fun chat(message: Message): Conversation {
-        _isChatInProgress.value = true
-        try {
-            currentChatJob?.cancel()
-
-            val conversation = this
-            currentChatJob = coroutineScope {
-                launch {
-                    try {
-                        addMessage(message)
-                        SlashCommandParser.parse(message.content).run(conversation)
-                    } finally {
-                        currentChatJob = null
-                    }
-                }
-            }
-            return this
-        } finally {
-            _isChatInProgress.value = false
-        }
-    }
-*/
 
     suspend fun chat(message: Message): Conversation {
         _isChatInProgress.value = true

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/ConversationPanel.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/ConversationPanel.kt
@@ -72,6 +72,17 @@ class ConversationPanel(conversation: Conversation, private val project: Project
     }
 
     internal fun updateMessageInProgress(update: String) {
+        if (update.isEmpty()) {
+            updatePanel?.let {
+                panel.remove(it)
+                Disposer.dispose(it)
+                updatePanel = null
+                panel.revalidate()
+                panel.repaint()
+            }
+            return
+        }
+
         if (updatePanel == null) {
             updatePanel = MessagePanel.create(Message.fromAssistant(update), project)
             Disposer.register(this, updatePanel!!)

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/StopButton.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/StopButton.kt
@@ -14,14 +14,10 @@ class StopButton(private val onStop: () -> Unit) : JButton() {
         border = JBUI.Borders.empty(4)
         isContentAreaFilled = false
         isFocusPainted = false
+        isEnabled = true
 
         addActionListener {
             onStop()
         }
-    }
-
-    fun updateVisibility(visible: Boolean) {
-        isVisible = visible
-        isEnabled = visible
     }
 }

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/StopButton.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/StopButton.kt
@@ -1,0 +1,27 @@
+package com.github.fmueller.jarvis.conversation
+
+import com.intellij.icons.AllIcons
+import com.intellij.util.ui.JBUI
+import java.awt.Dimension
+import javax.swing.JButton
+
+class StopButton(private val onStop: () -> Unit) : JButton() {
+
+    init {
+        icon = AllIcons.Actions.Suspend
+        toolTipText = "Stop generating response"
+        preferredSize = Dimension(32, 32)
+        border = JBUI.Borders.empty(4)
+        isContentAreaFilled = false
+        isFocusPainted = false
+
+        addActionListener {
+            onStop()
+        }
+    }
+
+    fun updateVisibility(visible: Boolean) {
+        isVisible = visible
+        isEnabled = visible
+    }
+}

--- a/src/main/kotlin/com/github/fmueller/jarvis/toolWindow/ConversationWindowFactory.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/toolWindow/ConversationWindowFactory.kt
@@ -33,6 +33,7 @@ class ConversationWindowFactory : ToolWindowFactory {
 
         private val stopButton: StopButton = StopButton {
             conversation.cancelCurrentChat()
+            conversation.addMessage(Message.info("Response generation was cancelled"))
             inputArea.isEnabled = true
             stopButton.isVisible = false
             inputArea.requestFocusInWindow()

--- a/src/main/kotlin/com/github/fmueller/jarvis/toolWindow/ConversationWindowFactory.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/toolWindow/ConversationWindowFactory.kt
@@ -34,7 +34,7 @@ class ConversationWindowFactory : ToolWindowFactory {
         private val stopButton: StopButton = StopButton {
             conversation.cancelCurrentChat()
             inputArea.isEnabled = true
-            stopButton.updateVisibility(false)
+            stopButton.isVisible = false
             inputArea.requestFocusInWindow()
         }
 
@@ -53,7 +53,7 @@ class ConversationWindowFactory : ToolWindowFactory {
                         GlobalScope.launch(Dispatchers.EDT) {
                             text = ""
                             isEnabled = false
-                            stopButton.updateVisibility(true)
+                            stopButton.isVisible = true
                             conversation.chat(Message(Role.USER, message, CodeContextHelper.getCodeContext(toolWindow.project)))
                         }
                     }
@@ -65,7 +65,7 @@ class ConversationWindowFactory : ToolWindowFactory {
             GlobalScope.launch(Dispatchers.EDT) {
                 conversation.isChatInProgress.collect { isInProgress ->
                     inputArea.isEnabled = !isInProgress
-                    stopButton.updateVisibility(isInProgress)
+                    stopButton.isVisible = isInProgress
                     if (!isInProgress) {
                         inputArea.requestFocusInWindow()
                     }
@@ -82,7 +82,7 @@ class ConversationWindowFactory : ToolWindowFactory {
 
                     add(JPanel(BorderLayout()).apply {
                         add(stopButton, BorderLayout.EAST)
-                        stopButton.updateVisibility(false)
+                        stopButton.isVisible = false
                     }, BorderLayout.EAST)
                 })
             })

--- a/src/test/kotlin/com/github/fmueller/jarvis/ai/http/CancellableHttpClientTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/ai/http/CancellableHttpClientTest.kt
@@ -1,0 +1,59 @@
+package com.github.fmueller.jarvis.ai.http
+
+import junit.framework.TestCase
+import okhttp3.Call
+
+class CancellableHttpClientTest : TestCase() {
+
+    fun `test getHttpClientBuilder returns OkHttpClientBuilder`() {
+        val client = CancellableHttpClient()
+        val builder = client.getHttpClientBuilder()
+
+        assertTrue("Builder should be instance of OkHttpClientBuilder", builder is OkHttpClientBuilder)
+        assertNotNull("Builder should not be null", builder)
+    }
+
+    fun `test setCurrentCall cancels previous call`() {
+        val client = CancellableHttpClient()
+
+        val firstCall = createMockCall()
+        val secondCall = createMockCall()
+
+        client.setCurrentCall(firstCall)
+        client.setCurrentCall(secondCall)
+
+        assertTrue("First call should be canceled", firstCall.isCanceled())
+    }
+
+    fun `test cancel cancels current call and sets it to null`() {
+        val client = CancellableHttpClient()
+        val call = createMockCall()
+
+        client.setCurrentCall(call)
+        client.cancel()
+        assertTrue("Call should be canceled", call.isCanceled())
+        
+        val newCall = createMockCall()
+        client.setCurrentCall(newCall)
+        assertFalse("New call should not be canceled yet", newCall.isCanceled())
+    }
+    
+    private fun createMockCall(): Call {
+        return object : Call {
+            private var canceled = false
+            
+            override fun cancel() {
+                canceled = true
+            }
+            
+            override fun isCanceled(): Boolean = canceled
+            
+            override fun request() = throw UnsupportedOperationException("Not needed for test")
+            override fun execute() = throw UnsupportedOperationException("Not needed for test")
+            override fun enqueue(responseCallback: okhttp3.Callback) = throw UnsupportedOperationException("Not needed for test")
+            override fun isExecuted(): Boolean = throw UnsupportedOperationException("Not needed for test")
+            override fun timeout() = throw UnsupportedOperationException("Not needed for test")
+            override fun clone(): Call = throw UnsupportedOperationException("Not needed for test")
+        }
+    }
+}

--- a/src/test/kotlin/com/github/fmueller/jarvis/ai/http/OkHttpClientAdapterTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/ai/http/OkHttpClientAdapterTest.kt
@@ -1,0 +1,268 @@
+package com.github.fmueller.jarvis.ai.http
+
+import dev.langchain4j.http.client.HttpMethod
+import dev.langchain4j.http.client.HttpRequest
+import dev.langchain4j.http.client.SuccessfulHttpResponse
+import dev.langchain4j.http.client.sse.ServerSentEvent
+import dev.langchain4j.http.client.sse.ServerSentEventListener
+import dev.langchain4j.http.client.sse.ServerSentEventParser
+import junit.framework.TestCase
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Headers
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+
+class OkHttpClientAdapterTest : TestCase() {
+
+    private lateinit var mockOkHttpClient: MockOkHttpClient
+    private lateinit var cancellableHttpClient: CancellableHttpClient
+    private lateinit var adapter: OkHttpClientAdapter
+
+    override fun setUp() {
+        super.setUp()
+
+        mockOkHttpClient = MockOkHttpClient()
+        cancellableHttpClient = CancellableHttpClient()
+        adapter = OkHttpClientAdapter(mockOkHttpClient, cancellableHttpClient)
+    }
+
+    fun `test execute GET request`() {
+        val responseBody = """{"message": "success"}"""
+        mockOkHttpClient.nextResponse = createMockResponse(200, responseBody)
+
+        val request = HttpRequest.builder()
+            .url("https://example.com/api")
+            .method(HttpMethod.GET)
+            .headers(mapOf("Accept" to listOf("application/json")))
+            .build()
+
+        val response = adapter.execute(request)
+
+        val capturedRequest = mockOkHttpClient.lastRequest
+        assertNotNull("Request should not be null", capturedRequest)
+        assertEquals("https://example.com/api", capturedRequest?.url.toString())
+        assertEquals("GET", capturedRequest?.method)
+        assertEquals("application/json", capturedRequest?.header("Accept"))
+
+        assertEquals(200, response.statusCode())
+        assertEquals(responseBody, response.body())
+        assertEquals("application/json", response.headers()["Content-Type"]?.firstOrNull())
+    }
+
+    fun `test execute POST request with body`() {
+        val responseBody = """{"id": 123}"""
+        mockOkHttpClient.nextResponse = createMockResponse(201, responseBody)
+
+        val requestBody = """{"name": "test"}"""
+        val request = HttpRequest.builder()
+            .url("https://example.com/api/create")
+            .method(HttpMethod.POST)
+            .headers(mapOf("Content-Type" to listOf("application/json")))
+            .body(requestBody)
+            .build()
+
+        val response = adapter.execute(request)
+
+        val capturedRequest = mockOkHttpClient.lastRequest
+        assertNotNull("Request should not be null", capturedRequest)
+        assertEquals("https://example.com/api/create", capturedRequest?.url.toString())
+        assertEquals("POST", capturedRequest?.method)
+        assertEquals("application/json", capturedRequest?.header("Content-Type"))
+
+        assertEquals(201, response.statusCode())
+        assertEquals(responseBody, response.body())
+    }
+
+    fun `test execute handles IOException`() {
+        mockOkHttpClient.shouldThrowIOException = true
+
+        val request = HttpRequest.builder()
+            .url("https://example.com/api")
+            .method(HttpMethod.GET)
+            .build()
+
+        try {
+            adapter.execute(request)
+            fail("Should have thrown RuntimeException")
+        } catch (e: RuntimeException) {
+            assertEquals("HTTP request failed", e.message)
+            assertTrue("Cause should be IOException", e.cause is IOException)
+        }
+    }
+
+    fun `test execute SSE request`() {
+        val sseContent = "data: event1\n\ndata: event2\n\n"
+        mockOkHttpClient.nextSseResponse = createMockResponse(200, sseContent)
+
+        val request = HttpRequest.builder()
+            .url("https://example.com/api/events")
+            .method(HttpMethod.GET)
+            .headers(mapOf("Accept" to listOf("text/event-stream")))
+            .build()
+
+        val mockParser = MockServerSentEventParser()
+        val mockListener = MockServerSentEventListener()
+
+        adapter.execute(request, mockParser, mockListener)
+
+        assertNotNull("SSE request should not be null", mockOkHttpClient.lastSseRequest)
+        assertEquals("https://example.com/api/events", mockOkHttpClient.lastSseRequest?.url.toString())
+        assertEquals("GET", mockOkHttpClient.lastSseRequest?.method)
+        assertEquals("text/event-stream", mockOkHttpClient.lastSseRequest?.header("Accept"))
+
+        assertTrue("Parser should have been called", mockParser.wasCalled)
+        assertNotNull("Parser input stream should not be null", mockParser.lastInputStream)
+
+        assertNotNull("Current call should be set", mockOkHttpClient.lastCall)
+    }
+
+    fun `test execute SSE handles error response`() {
+        mockOkHttpClient.nextSseResponse = createMockResponse(500, "Server Error")
+
+        val request = HttpRequest.builder()
+            .url("https://example.com/api/events")
+            .method(HttpMethod.GET)
+            .build()
+
+        val mockParser = MockServerSentEventParser()
+        val mockListener = MockServerSentEventListener()
+
+        adapter.execute(request, mockParser, mockListener)
+
+        assertTrue("Listener should have received error", mockListener.receivedError)
+
+        println("[DEBUG_LOG] Actual error message: ${mockListener.lastError?.message}")
+
+        assertEquals("SSE request failed", mockListener.lastError?.message)
+    }
+
+    fun `test execute SSE with null parameters throws exception`() {
+        try {
+            adapter.execute(null, null, null)
+            fail("Should have thrown IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertEquals("Request, parser, and listener cannot be null", e.message)
+        }
+    }
+
+    private fun createMockResponse(statusCode: Int, body: String): Response {
+        return Response.Builder()
+            .request(Request.Builder().url("https://example.com").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(statusCode)
+            .message(if (statusCode >= 400) "Error" else "OK")
+            .header("Content-Type", "application/json")
+            .body(body.toResponseBody("application/json".toMediaType()))
+            .build()
+    }
+
+    private class MockOkHttpClient : OkHttpClient() {
+        var nextResponse: Response? = null
+        var nextSseResponse: Response? = null
+        var lastRequest: Request? = null
+        var lastSseRequest: Request? = null
+        var lastCall: Call? = null
+        var shouldThrowIOException = false
+
+        override fun newCall(request: Request): Call {
+            return if (request.header("Accept") == "text/event-stream") {
+                lastSseRequest = request
+                MockCall(this, request, nextSseResponse)
+            } else {
+                lastRequest = request
+                MockCall(this, request, nextResponse)
+            }
+        }
+
+        inner class MockCall(
+            private val client: MockOkHttpClient,
+            private val request: Request,
+            private val response: Response?
+        ) : Call {
+            private var canceled = false
+            private var executed = false
+
+            init {
+                lastCall = this
+            }
+
+            override fun execute(): Response {
+                executed = true
+                if (shouldThrowIOException) {
+                    throw IOException("Simulated network error")
+                }
+                return response ?: throw IOException("No mock response provided")
+            }
+
+            override fun enqueue(callback: Callback) {
+                if (canceled) {
+                    return
+                }
+
+                executed = true
+
+                if (shouldThrowIOException) {
+                    callback.onFailure(this, IOException("Simulated network error"))
+                    return
+                }
+
+                val resp = response ?: run {
+                    callback.onFailure(this, IOException("No mock response provided"))
+                    return
+                }
+
+                callback.onResponse(this, resp)
+            }
+
+            override fun cancel() {
+                canceled = true
+            }
+
+            override fun isCanceled(): Boolean = canceled
+            override fun isExecuted(): Boolean = executed
+            override fun request(): Request = request
+            override fun timeout() = throw UnsupportedOperationException("Not needed for test")
+            override fun clone(): Call = MockCall(client, request, response)
+        }
+    }
+
+    private class MockServerSentEventParser : ServerSentEventParser {
+        var wasCalled = false
+        var lastInputStream: InputStream? = null
+
+        override fun parse(inputStream: InputStream, listener: ServerSentEventListener) {
+            wasCalled = true
+            lastInputStream = inputStream
+
+            // Simulate parsing events from the input stream
+        }
+    }
+
+    private class MockServerSentEventListener : ServerSentEventListener {
+        var receivedError = false
+        var lastError: Throwable? = null
+        var openCalled = false
+        var eventReceived = false
+
+        override fun onOpen(response: SuccessfulHttpResponse) {
+            openCalled = true
+        }
+
+        override fun onEvent(event: ServerSentEvent) {
+            eventReceived = true
+        }
+
+        override fun onError(throwable: Throwable) {
+            receivedError = true
+            lastError = throwable
+        }
+    }
+}

--- a/src/test/kotlin/com/github/fmueller/jarvis/ai/http/OkHttpClientBuilderTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/ai/http/OkHttpClientBuilderTest.kt
@@ -1,0 +1,76 @@
+package com.github.fmueller.jarvis.ai.http
+
+import dev.langchain4j.http.client.HttpClient
+import junit.framework.TestCase
+import java.time.Duration
+
+class OkHttpClientBuilderTest : TestCase() {
+
+    private lateinit var cancellableHttpClient: CancellableHttpClient
+    private lateinit var builder: OkHttpClientBuilder
+
+    override fun setUp() {
+        super.setUp()
+        cancellableHttpClient = CancellableHttpClient()
+        builder = OkHttpClientBuilder(cancellableHttpClient)
+    }
+
+    fun `test default timeouts`() {
+        assertEquals(Duration.ofSeconds(30), builder.connectTimeout())
+        assertEquals(Duration.ofSeconds(5), builder.readTimeout())
+    }
+
+    fun `test setting connect timeout`() {
+        val timeout = Duration.ofSeconds(60)
+        val result = builder.connectTimeout(timeout)
+
+        assertSame(builder, result)
+
+        assertEquals(timeout, builder.connectTimeout())
+    }
+
+    fun `test setting read timeout`() {
+        val timeout = Duration.ofSeconds(10)
+        val result = builder.readTimeout(timeout)
+
+        assertSame(builder, result)
+
+        assertEquals(timeout, builder.readTimeout())
+    }
+
+    fun `test setting null timeouts has no effect`() {
+        val originalConnectTimeout = builder.connectTimeout()
+        val originalReadTimeout = builder.readTimeout()
+
+        builder.connectTimeout(null)
+        builder.readTimeout(null)
+
+        assertEquals(originalConnectTimeout, builder.connectTimeout())
+        assertEquals(originalReadTimeout, builder.readTimeout())
+    }
+
+    fun `test build returns OkHttpClientAdapter`() {
+        val client = builder.build()
+
+        assertNotNull("Client should not be null", client)
+        assertTrue("Client should be instance of HttpClient", client is HttpClient)
+        assertTrue("Client should be instance of OkHttpClientAdapter", client is OkHttpClientAdapter)
+    }
+
+    fun `test build with custom timeouts`() {
+        val connectTimeout = Duration.ofSeconds(45)
+        val readTimeout = Duration.ofSeconds(15)
+
+        builder.connectTimeout(connectTimeout)
+        builder.readTimeout(readTimeout)
+
+        val client = builder.build()
+
+        assertNotNull("Client should not be null", client)
+        assertTrue("Client should be instance of OkHttpClientAdapter", client is OkHttpClientAdapter)
+        
+        // Note: We can't directly test the internal OkHttpClient's timeouts
+        // as they're private to the OkHttpClientAdapter, but we've verified
+        // that the builder correctly stores the timeout values
+    }
+}

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/ConversationPanelTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/ConversationPanelTest.kt
@@ -197,4 +197,20 @@ class ConversationPanelTest : BasePlatformTestCase() {
                 fewerMessages[0], (comp as MessagePanel).message)
         }
     }
+
+    fun `test updateMessageInProgress with empty update removes existing panel`() {
+        runInEdtAndGet {
+            conversationPanel.updateMessageInProgress("Temporary")
+        }
+        assertNotNull("updatePanel should be non-null after initial update", conversationPanel.updatePanel)
+        val initialCount = runInEdtAndGet { conversationPanel.panel.componentCount }
+
+        runInEdtAndGet {
+            conversationPanel.updateMessageInProgress("")
+        }
+
+        assertNull("updatePanel should be null after empty update", conversationPanel.updatePanel)
+        val newCount = runInEdtAndGet { conversationPanel.panel.componentCount }
+        assertTrue("Panel should have fewer components after removing the update panel", newCount < initialCount)
+    }
 }

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/ConversationTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/ConversationTest.kt
@@ -80,4 +80,20 @@ class ConversationTest : TestCase() {
 
         assertEquals("Hello", closed)
     }
+
+    fun `test clearMessageBeingGenerated fires correct property changes`() {
+        val events = mutableListOf<Pair<String, String>>()
+        conversation.addPropertyChangeListener(PropertyChangeListener { evt ->
+            if (evt.propertyName == "messageBeingGenerated") {
+                events.add(evt.oldValue as String to evt.newValue as String)
+            }
+        })
+
+        conversation.addToMessageBeingGenerated("hello")
+        conversation.addMessage(Message.fromAssistant("test"))
+
+        assertEquals(2, events.size)
+        assertEquals("" to "hello", events[0])
+        assertEquals("hello" to "", events[1])
+    }
 }


### PR DESCRIPTION
That is the first working prototype of interruptable messages, displaying a stop button in the UI when a response is being generated, allowing the user to stop it. The underlying request to Ollama will be canceled, which also stops the inference.