### PR TITLE
Improve release workflow disk handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,13 @@ jobs:
       pull-requests: write
     steps:
 
+      # Free GitHub Actions Environment Disk Space
+      - name: Maximize Build Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          large-packages: true
+
       # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- free disk space before the Publish Plugin step in release workflow

## Testing
- `gradle build`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_686588327a64832db2f6c71ae7919afa