### PR TITLE
Add ConversationWindow tests

### DIFF
--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/Conversation.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.jetbrains.annotations.VisibleForTesting
 import java.beans.PropertyChangeListener
 import java.beans.PropertyChangeSupport
 import java.time.LocalDateTime
@@ -161,6 +162,15 @@ class Conversation : Disposable {
                 !it.content.startsWith("/model ") &&
                 !it.content.startsWith("/host ")
         } == 1
+
+    /**
+     * Sets the chat in progress state for testing purposes.
+     */
+    @VisibleForTesting
+    internal fun markChatInProgressForTesting(inProgress: Boolean) {
+        _isChatInProgress.value = inProgress
+        currentChatJob = if (inProgress) Job() else null
+    }
 
     fun addToMessageBeingGenerated(text: String) {
         val old = _messageBeingGenerated.toString()

--- a/src/test/kotlin/com/github/fmueller/jarvis/toolWindow/ConversationWindowFactoryTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/toolWindow/ConversationWindowFactoryTest.kt
@@ -1,0 +1,78 @@
+package com.github.fmueller.jarvis.toolWindow
+
+import com.github.fmueller.jarvis.conversation.Conversation
+import com.github.fmueller.jarvis.conversation.Role
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.*
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.runInEdtAndWait
+
+class ConversationWindowFactoryTest : BasePlatformTestCase() {
+
+    private lateinit var conversation: Conversation
+    private lateinit var window: ConversationWindowFactory.ConversationWindow
+
+    override fun setUp() {
+        super.setUp()
+        conversation = Conversation()
+        window = ConversationWindowFactory.ConversationWindow(project, conversation, true)
+    }
+
+    override fun tearDown() {
+        conversation.dispose()
+        super.tearDown()
+    }
+
+    private fun createEvent(): AnActionEvent {
+        return AnActionEvent(
+            null,
+            DataContext.EMPTY_CONTEXT,
+            "",
+            Presentation(),
+            ActionManager.getInstance(),
+            0
+        )
+    }
+
+    fun `test send button disabled for empty input`() {
+        val event = createEvent()
+        runInEdtAndWait {
+            window.inputArea.text = ""
+            window.sendAction.update(event)
+        }
+        assertFalse(event.presentation.isEnabled)
+    }
+
+    fun `test send button sends message`() {
+        runInEdtAndWait {
+            window.inputArea.text = "/help"
+            window.sendAction.actionPerformed(createEvent())
+        }
+        assertEquals(3, conversation.messages.size)
+        val userMessage = conversation.messages[1]
+        assertEquals(Role.USER, userMessage.role)
+        assertEquals("/help", userMessage.content)
+    }
+
+    fun `test send button cancels chat when in progress`() {
+        conversation.markChatInProgressForTesting(true)
+        runInEdtAndWait {
+            window.sendAction.actionPerformed(createEvent())
+        }
+        val last = conversation.messages.last()
+        assertEquals(Role.INFO, last.role)
+        assertTrue(last.content.contains("cancelled"))
+        assertTrue(window.inputArea.isEnabled)
+    }
+
+    fun `test send button presentation when in progress`() {
+        conversation.markChatInProgressForTesting(true)
+        val event = createEvent()
+        runInEdtAndWait {
+            window.sendAction.update(event)
+        }
+        assertEquals("Stop", event.presentation.text)
+        assertEquals(AllIcons.Actions.Suspend, event.presentation.icon)
+        assertTrue(event.presentation.isEnabled)
+    }
+}


### PR DESCRIPTION
## Summary
- expose ConversationWindow internals for testing
- add helper in Conversation to mark chat in progress
- add tests for ConversationWindow's send button behavior

## Testing
- `gradle test --tests "*ConversationWindowFactoryTest" --no-daemon --console=plain`
- `gradle check --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68658e8a17e0832d8d25ad20d3c6d118