### PR TITLE
Add cache cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,20 @@
+name: Cleanup PR Caches
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches for branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="${{ github.event.pull_request.head.ref }}"
+          echo "Removing caches for $branch"
+          gh api -X DELETE "repos/${{ github.repository }}/actions/caches?branch=$branch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Remove caches for closed pull requests in CI
+
 ## [1.7.3] - 2025-07-03
 
 ### Added


### PR DESCRIPTION
## Summary
- automatically purge GitHub Actions caches when a pull request is closed
- note the cleanup job in the changelog

## Testing
- `gradle build`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_68721a93aa10832d8756f5c1675f54df