### PR TITLE
fix: ignore missing cache in cleanup

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -18,4 +18,4 @@ jobs:
           branch="${{ github.event.pull_request.head.ref }}"
           ref="refs/heads/$branch"
           echo "Removing caches for $branch"
-          gh api -X DELETE "repos/${{ github.repository }}/actions/caches?key=$branch&ref=$ref"
+          gh api -X DELETE "repos/${{ github.repository }}/actions/caches?key=$branch&ref=$ref" || echo "No caches found"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove caches for closed pull requests in CI
 
+### Fixed
+
+- Do not fail CI cache cleanup when no cache is found
+
 ## [1.7.3] - 2025-07-03
 
 ### Added


### PR DESCRIPTION
## Summary
- make cleanup CI job ignore 404 when caches are missing
- document fix in changelog

## Testing
- `gradle build`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_68756f2c00d0832d9892dd62a9b84c09