### PR TITLE
Refactor reasoning parsing into domain

### DIFF
--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessageTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessageTest.kt
@@ -1,0 +1,37 @@
+package com.github.fmueller.jarvis.conversation
+
+import junit.framework.TestCase
+
+class MessageTest : TestCase() {
+
+    fun `test parseReasoning returns reasoning and remaining text`() {
+        val message = Message.fromAssistant("<think>Reason</think>Hello")
+
+        val (reasoning, remaining) = message.parseReasoning()
+
+        assertNotNull(reasoning)
+        assertEquals("Reason", reasoning?.markdown)
+        assertFalse(reasoning?.isInProgress ?: true)
+        assertEquals("Hello", remaining)
+    }
+
+    fun `test parseReasoning unfinished reasoning`() {
+        val message = Message.fromAssistant("<think>Reasoning in progress")
+
+        val (reasoning, remaining) = message.parseReasoning()
+
+        assertNotNull(reasoning)
+        assertEquals("Reasoning in progress", reasoning?.markdown)
+        assertTrue(reasoning?.isInProgress ?: false)
+        assertEquals("", remaining)
+    }
+
+    fun `test parseReasoning with no reasoning`() {
+        val message = Message.fromAssistant("Hello")
+
+        val (reasoning, remaining) = message.parseReasoning()
+
+        assertNull(reasoning)
+        assertEquals("Hello", remaining)
+    }
+}


### PR DESCRIPTION
## Summary
- move reasoning parsing from UI to `Message`
- adjust `MessagePanel` to use new parsing logic
- add unit tests for reasoning parsing

## Testing
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_68721a68f140832dba9adc11f65a469d