### PR TITLE
ci: trim large GitHub Actions caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,9 +119,6 @@ jobs:
           gradle-home-cache-excludes: |
             caches/*/transforms-*
             caches/transforms-*
-          gradle-home-cache-excludes: |
-            caches/*/transforms-*
-            caches/transforms-*
 
       # Run tests
       - name: Run Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,10 @@ jobs:
       # Setup Gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-excludes: |
+            caches/*/transforms-*
+            caches/transforms-*
 
       # Set environment variables
       - name: Export Properties
@@ -112,6 +116,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-home-cache-cleanup: true
+          gradle-home-cache-excludes: |
+            caches/*/transforms-*
+            caches/transforms-*
+          gradle-home-cache-excludes: |
+            caches/*/transforms-*
+            caches/transforms-*
 
       # Run tests
       - name: Run Tests
@@ -167,7 +177,7 @@ jobs:
       - name: Qodana - Code Inspection
         uses: JetBrains/qodana-action@v2025.1
         with:
-          cache-default-branch-only: true
+          use-caches: false
 
   # Run plugin structure verification along with IntelliJ Plugin Verifier
   verify:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-home-cache-cleanup: true
+          gradle-home-cache-excludes: |
+            caches/*/transforms-*
+            caches/transforms-*
 
       # Set environment variables
       - name: Export Properties

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -45,6 +45,10 @@ jobs:
       # Setup Gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-excludes: |
+            caches/*/transforms-*
+            caches/transforms-*
 
       # Run IDEA prepared for UI testing
       - name: Run IDE


### PR DESCRIPTION
## Summary
- avoid caching Gradle transform directories
- disable Qodana caching

## Testing
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_6895a486d648832d9f5ca0825fc220df