### PR TITLE
feat: add configurable context window size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Remove caches for closed pull requests in CI
+- Configurable context window size when calling Ollama
 
 ### Fixed
 

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
@@ -144,6 +144,15 @@ object OllamaService {
             assistant = createAiService()
         }
 
+    /**
+     * Maximum number of tokens sent as context to Ollama.
+     */
+    var contextWindowSize: Int = 4096
+        set(value) {
+            field = value
+            assistant = createAiService()
+        }
+
     private var assistant = createAiService()
 
     fun clearChatMemory() {
@@ -350,6 +359,7 @@ object OllamaService {
                     .timeout(Duration.ofMinutes(5))
                     .baseUrl(host)
                     .modelName(modelName)
+                    .numCtx(contextWindowSize)
                     .build()
             )
             .systemMessageProvider { chatMemoryId -> systemPrompt }

--- a/src/test/kotlin/com/github/fmueller/jarvis/ai/OllamaServiceContextWindowSizeTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/ai/OllamaServiceContextWindowSizeTest.kt
@@ -1,0 +1,22 @@
+package com.github.fmueller.jarvis.ai
+
+import junit.framework.TestCase
+
+class OllamaServiceContextWindowSizeTest : TestCase() {
+
+    fun `test default context window size`() {
+        assertEquals(4096, OllamaService.contextWindowSize)
+    }
+
+    fun `test changing context window size recreates assistant`() {
+        val assistantField = OllamaService::class.java.getDeclaredField("assistant")
+        assistantField.isAccessible = true
+        val initialAssistant = assistantField.get(OllamaService)
+
+        OllamaService.contextWindowSize = 1234
+
+        val newAssistant = assistantField.get(OllamaService)
+        assertNotSame(initialAssistant, newAssistant)
+        assertEquals(1234, OllamaService.contextWindowSize)
+    }
+}


### PR DESCRIPTION
## Summary
- allow configuring context window size for Ollama requests
- document the new parameter
- cover the default and reassignment behavior with tests

## Testing
- `gradle build`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_6895a4d9ad60832da3991a5b2d5d990c