### PR TITLE
feat: animate reasoning panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove caches for closed pull requests in CI
 - Configurable context window size when calling Ollama
+- Animated reasoning panel showing incremental paragraphs
 
 ### Fixed
 

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/ReasoningMessagePanel.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/ReasoningMessagePanel.kt
@@ -1,0 +1,44 @@
+package com.github.fmueller.jarvis.conversation
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import org.jetbrains.annotations.VisibleForTesting
+import java.awt.BorderLayout
+import javax.swing.JPanel
+
+class ReasoningMessagePanel(
+    project: Project
+) : JPanel(), Disposable {
+
+    private val innerPanel = MessagePanel.create(Message.fromAssistant(""), project, true)
+
+    @VisibleForTesting
+    var displayedText: String = ""
+        private set
+
+    init {
+        layout = BorderLayout()
+        innerPanel.border = null
+        add(innerPanel, BorderLayout.CENTER)
+    }
+
+    fun update(reasoning: Message.Reasoning) {
+        val text = if (reasoning.isInProgress) {
+            extractLastFullParagraph(reasoning.markdown)
+        } else {
+            reasoning.markdown
+        }
+        displayedText = text
+        innerPanel.message = Message.fromAssistant(text)
+    }
+
+    private fun extractLastFullParagraph(markdown: String): String {
+        val paragraphs = markdown.split("\n\n")
+        return paragraphs.dropLast(1).lastOrNull()?.trim() ?: ""
+    }
+
+    override fun dispose() {
+        innerPanel.dispose()
+    }
+}
+

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
@@ -172,7 +172,13 @@ class MessagePanelTest : BasePlatformTestCase() {
         messagePanel.message = Message.fromAssistant("<think>Reason</think>Hello")
 
         assertEquals(1, messagePanel.parsed.size)
-        assertTrue(messagePanel.reasoningMessagePanel?.message?.content?.contains("Reason") ?: false)
+        assertTrue(messagePanel.reasoningMessagePanel?.displayedText?.contains("Reason") ?: false)
+    }
+
+    fun `test reasoning panel shows last paragraph when in progress`() {
+        messagePanel.message = Message.fromAssistant("<think>First paragraph.\n\nSecond incomplete")
+
+        assertEquals("First paragraph.", messagePanel.reasoningMessagePanel?.displayedText)
     }
 
     fun `test reasoning panel toggle functionality`() {


### PR DESCRIPTION
## Summary
- show reasoning in dedicated panel that only displays the last full paragraph while response is streaming
- animate reasoning header with looping dots when generation is in progress
- dim reasoning text colors for a subtler appearance

## Testing
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_6895be973624832daea44f7f9feb12a8