### PR TITLE
fix: preserve scroll position while streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Do not fail CI cache cleanup when no cache is found
 - Use configured context window size for chat memory token limit
+- Avoid auto-scrolling during streamed responses
 
 ## [1.7.3] - 2025-07-03
 

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/ConversationPanel.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/ConversationPanel.kt
@@ -51,7 +51,9 @@ class ConversationPanel(conversation: Conversation, private val project: Project
         conversation.addPropertyChangeListener {
             if (it.propertyName == "messages") {
                 SwingUtilities.invokeLater {
-                    isUserScrolling = false
+                    if (updatePanel == null) {
+                        isUserScrolling = false
+                    }
                     val newMessages = (it.newValue as? List<*>)?.filterIsInstance<Message>()
                     if (newMessages == null) {
                         throw IllegalStateException("Property 'messages' must be a list of messages")
@@ -64,7 +66,9 @@ class ConversationPanel(conversation: Conversation, private val project: Project
         conversation.addPropertyChangeListener {
             if (it.propertyName == "messageBeingGenerated") {
                 SwingUtilities.invokeLater {
-                    isUserScrolling = false
+                    if (updatePanel == null) {
+                        isUserScrolling = true
+                    }
                     updateMessageInProgress(it.newValue as String)
                 }
             }

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/ConversationPanelTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/ConversationPanelTest.kt
@@ -362,4 +362,19 @@ class ConversationPanelTest : BasePlatformTestCase() {
         val newCount = runInEdtAndGet { conversationPanel.panel.componentCount }
         assertTrue("Panel should have fewer components after removing the update panel", newCount < initialCount)
     }
+
+    fun `test scroll position remains during message generation`() {
+        val longText = (1..100).joinToString("\n") { "Line $it" }
+        val scrollBar = conversationPanel.scrollableContainer.verticalScrollBar
+        val initialValue = scrollBar.value
+
+        conversation.addToMessageBeingGenerated(longText)
+        waitForEDT()
+
+        assertEquals(
+            "Scroll position should remain unchanged during streaming",
+            initialValue,
+            scrollBar.value
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- prevent conversation scroll pane from auto-scrolling during streamed responses
- add regression test for scroll position
- note scroll fix in changelog

## Testing
- `gradle build`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_689ceb0718ec832daa10aa9fd4a377f7