### PR TITLE
feat: fade in completed responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Do not fail CI cache cleanup when no cache is found
 - Use configured context window size for chat memory token limit
 
+### Changed
+
+- Fade in completed LLM responses for quicker display
+
 ## [1.7.3] - 2025-07-03
 
 ### Added

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
@@ -338,4 +338,12 @@ class MessagePanelTest : BasePlatformTestCase() {
         // Should have one less component (removed the second code block)
         assertEquals(initialComponentCount - 1, messagePanel.componentCount)
     }
+
+    fun `test fadeInFinalMessage sets alpha to zero and updates content`() {
+        runInEdtAndGet {
+            messagePanel.fadeInFinalMessage(Message.fromAssistant("Final"))
+        }
+        assertEquals("Final", messagePanel.message.content)
+        assertEquals(0f, messagePanel.currentAlpha)
+    }
 }


### PR DESCRIPTION
## Summary
- fade completed LLM responses into view
- track completion in conversation panel to trigger fade effect
- test fade animation on message panel

## Testing
- `gradle build`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_689ceab53fd0832db1459468c8278b16