### PR TITLE
feat: fade in completed responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Do not fail CI cache cleanup when no cache is found
 - Use configured context window size for chat memory token limit
 
+### Changed
+
+- Fade in completed LLM responses only when faster than the normal typing animation
+
 ## [1.7.3] - 2025-07-03
 
 ### Added

--- a/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/conversation/MessagePanel.kt
@@ -18,10 +18,14 @@ import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.util.data.MutableDataSet
 import org.jdesktop.swingx.VerticalLayout
 import org.jetbrains.annotations.VisibleForTesting
+import java.awt.AlphaComposite
 import java.awt.BorderLayout
 import java.awt.Font
+import java.awt.Graphics
+import java.awt.Graphics2D
 import java.util.regex.Pattern
 import javax.swing.*
+import kotlin.math.ceil
 
 class MessagePanel(
     initialMessage: Message,
@@ -35,6 +39,9 @@ class MessagePanel(
         private const val UPDATE_DELAY_MS = 100
         private const val MIN_CONTENT_CHANGE = 5
         private const val MIN_UPDATE_INTERVAL_MS = 50
+        private const val FADE_IN_DELAY_MS = 30
+        private const val FADE_IN_STEP = 0.1f
+        private const val TYPING_MS_PER_CHAR = UPDATE_DELAY_MS / MIN_CONTENT_CHANGE
 
         private val codeBlockPattern = Pattern.compile("`{2,}(\\w+)?\\n(.*?)\\n\\s*`{2,}", Pattern.DOTALL)
 
@@ -65,6 +72,9 @@ class MessagePanel(
     private var pendingMessage: Message? = null
     private var lastUpdateTime = 0L
     private var lastRenderedContentLength = 0
+    @VisibleForTesting
+    internal var currentAlpha = 1f
+    private var fadeTimer: Timer? = null
 
     sealed interface ParsedContent
     data class Content(val markdown: String) : ParsedContent
@@ -117,8 +127,19 @@ class MessagePanel(
         updatePanel(message)
     }
 
+    override fun paint(g: Graphics) {
+        val g2 = g as Graphics2D
+        val original = g2.composite
+        if (currentAlpha < 1f) {
+            g2.composite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, currentAlpha)
+        }
+        super.paint(g2)
+        g2.composite = original
+    }
+
     override fun dispose() {
         updateTimer.stop()
+        fadeTimer?.stop()
         parsed.clear()
         highlightedCodeHelper.disposeAllEditors()
         reasoningMessagePanel?.dispose()
@@ -155,6 +176,41 @@ class MessagePanel(
         lastRenderedContentLength = messageToRender.content.length
         SwingUtilities.invokeLater {
             updatePanel(messageToRender)
+        }
+    }
+
+    /**
+     * Displays the provided message immediately and fades it in if fading is faster than the normal typing animation.
+     */
+    internal fun fadeInFinalMessage(finalMessage: Message? = null) {
+        updateTimer.stop()
+        pendingMessage = null
+
+        finalMessage?.let {
+            _message = it
+            updatePanel(it)
+        }
+
+        val targetMessage = finalMessage ?: _message
+        val typingDurationMs = targetMessage.content.length * TYPING_MS_PER_CHAR
+        val fadeSteps = ceil(1f / FADE_IN_STEP).toInt()
+        val fadeDurationMs = fadeSteps * FADE_IN_DELAY_MS
+
+        if (fadeDurationMs < typingDurationMs) {
+            currentAlpha = 0f
+            fadeTimer?.stop()
+            fadeTimer = Timer(FADE_IN_DELAY_MS) {
+                currentAlpha = (currentAlpha + FADE_IN_STEP).coerceAtMost(1f)
+                repaint()
+                if (currentAlpha >= 1f) {
+                    fadeTimer?.stop()
+                }
+            }
+            fadeTimer?.start()
+        } else {
+            currentAlpha = 1f
+            fadeTimer?.stop()
+            repaint()
         }
     }
 

--- a/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/conversation/MessagePanelTest.kt
@@ -338,4 +338,21 @@ class MessagePanelTest : BasePlatformTestCase() {
         // Should have one less component (removed the second code block)
         assertEquals(initialComponentCount - 1, messagePanel.componentCount)
     }
+
+    fun `test fadeInFinalMessage fades when faster than typing`() {
+        val longMessage = "a".repeat(100)
+        runInEdtAndGet {
+            messagePanel.fadeInFinalMessage(Message.fromAssistant(longMessage))
+        }
+        assertEquals(longMessage, messagePanel.message.content)
+        assertEquals(0f, messagePanel.currentAlpha)
+    }
+
+    fun `test fadeInFinalMessage skips fade for short messages`() {
+        runInEdtAndGet {
+            messagePanel.fadeInFinalMessage(Message.fromAssistant("Short"))
+        }
+        assertEquals("Short", messagePanel.message.content)
+        assertEquals(1f, messagePanel.currentAlpha)
+    }
 }


### PR DESCRIPTION
## Summary
- fade completed LLM responses only when faster than standard typing animation
- test fade logic for short and long messages

## Testing
- `gradle build`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_689ceab53fd0832db1459468c8278b16