### PR TITLE
feat: add model parameter configuration command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove caches for closed pull requests in CI
 - Configurable context window size when calling Ollama
 - `/model` shows model info when no name is supplied and new `/model-info` command
+- `/model set` command to configure inference parameters
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Available commands:
 - ```/copy``` - Copies the conversation to the clipboard
 - ```/model <modelName>``` - Changes the model to use (model name `default` is `qwen3:1.7b`)
 - ```/model``` or ```/model-info``` - Shows the info card of the current model
+- ```/model set -<parameter> <value>``` - Configures model inference parameters
 - ```/host <host>``` - Sets the Ollama host (host `default` is `http://localhost:11434`)
 
 When using reasoning models with Ollama, Jarvis shows their internal thoughts in an expandable section at the top of each answer.

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
@@ -565,7 +565,9 @@ object OllamaService {
     private fun createAiService(): Assistant {
         cancelCurrentRequest()
         currentInferenceClient = CancellableHttpClient()
-        val paramsBuilder = DefaultChatRequestParameters.builder()
+
+        val paramsBuilder = OllamaChatRequestParameters.builder()
+            .keepAlive(Duration.ofMinutes(5).toSeconds().toInt())
             .temperature(temperature)
             .topP(topP)
             .topK(topK)
@@ -575,7 +577,7 @@ object OllamaService {
         if (stopSequences.isNotEmpty()) {
             paramsBuilder.stopSequences(stopSequences)
         }
-        val defaultParams = paramsBuilder.build()
+
         return AiServices
             .builder(Assistant::class.java)
             .streamingChatModel(
@@ -587,12 +589,7 @@ object OllamaService {
                     .numCtx(contextWindowSize)
                     .repeatPenalty(repeatPenalty)
                     .seed(seed)
-                    .defaultRequestParameters(defaultParams)
-                    .defaultRequestParameters(
-                        OllamaChatRequestParameters.builder()
-                            .keepAlive(Duration.ofMinutes(5).toSeconds().toInt())
-                            .build()
-                    )
+                    .defaultRequestParameters(paramsBuilder.build())
                     .build()
             )
             .systemMessageProvider { chatMemoryId -> systemPrompt }

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
@@ -169,8 +169,6 @@ object OllamaService {
 
     var seed: Int? = null
 
-    var stopSequences: List<String> = emptyList()
-
     var presencePenalty: Double? = null
 
     var frequencyPenalty: Double? = null
@@ -182,7 +180,6 @@ object OllamaService {
         maxTokens = null
         repeatPenalty = 1.1
         seed = null
-        stopSequences = emptyList()
         presencePenalty = null
         frequencyPenalty = null
     }
@@ -258,10 +255,6 @@ object OllamaService {
                     "num_ctx must be between 512 and 32768"
                 }
             }
-            "stop" -> {
-                stopSequences = value.split(",").map { it.trim() }.filter { it.isNotEmpty() }
-                null
-            }
             "presence_penalty", "pp" -> "presence_penalty is not supported"
             "frequency_penalty", "fp" -> "frequency_penalty is not supported"
             else -> "unsupported parameter $name"
@@ -278,9 +271,6 @@ object OllamaService {
         result.append("    repeat_penalty     $repeatPenalty    Prevents repetition\n")
         result.append("    seed               ${seed ?: "random"}    For reproducible outputs\n")
         result.append("    num_ctx            $contextWindowSize    Context window size\n")
-        if (stopSequences.isNotEmpty()) {
-            result.append("    stop               ${stopSequences.joinToString()}    Stop sequences\n")
-        }
         result.append(
             "    presence_penalty   ${presencePenalty ?: 0.0}    Penalizes repeated topics\n",
         )
@@ -574,9 +564,6 @@ object OllamaService {
             .maxOutputTokens(maxTokens)
             .presencePenalty(presencePenalty)
             .frequencyPenalty(frequencyPenalty)
-        if (stopSequences.isNotEmpty()) {
-            paramsBuilder.stopSequences(stopSequences)
-        }
 
         return AiServices
             .builder(Assistant::class.java)

--- a/src/main/kotlin/com/github/fmueller/jarvis/commands/ModelSetCommand.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/commands/ModelSetCommand.kt
@@ -1,0 +1,37 @@
+package com.github.fmueller.jarvis.commands
+
+import com.github.fmueller.jarvis.ai.OllamaService
+import com.github.fmueller.jarvis.conversation.Conversation
+import com.github.fmueller.jarvis.conversation.Message
+
+/**
+ * Command to configure inference parameters of the current model.
+ *
+ * Supported syntax: `/model set -<parameter> <value>`
+ * Multiple parameter-value pairs can be provided in one invocation.
+ */
+class ModelSetCommand(private val params: Map<String, String>) : SlashCommand {
+
+    override suspend fun run(conversation: Conversation): Conversation {
+        if (params.isEmpty()) {
+            conversation.addMessage(Message.info("No parameters specified"))
+            return conversation
+        }
+        val errors = mutableListOf<String>()
+        params.forEach { (name, value) ->
+            val error = OllamaService.setParameter(name, value)
+            if (error != null) {
+                errors.add(error)
+            }
+        }
+        OllamaService.clearChatMemory()
+        val message = if (errors.isEmpty()) {
+            "Parameters updated"
+        } else {
+            errors.joinToString("\n")
+        }
+        conversation.addMessage(Message.info(message))
+        return conversation
+    }
+}
+

--- a/src/main/kotlin/com/github/fmueller/jarvis/commands/SlashCommandParser.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/commands/SlashCommandParser.kt
@@ -3,7 +3,8 @@ package com.github.fmueller.jarvis.commands
 object SlashCommandParser {
 
     fun parse(message: String): SlashCommand {
-        val trimmedMessage = message.trim().lowercase()
+        val trimmed = message.trim()
+        val trimmedMessage = trimmed.lowercase()
         if (trimmedMessage == "/help" || trimmedMessage == "/?") {
             return HelpCommand()
         }
@@ -18,6 +19,26 @@ object SlashCommandParser {
 
         if (trimmedMessage == "/model" || trimmedMessage == "/model-info") {
             return ModelCommand()
+        }
+
+        if (trimmedMessage.startsWith("/model set")) {
+            val paramsPart = trimmed.removePrefix("/model set").trim()
+            val tokens = paramsPart.split(" ")
+            val params = mutableMapOf<String, String>()
+            var i = 0
+            while (i < tokens.size) {
+                val token = tokens[i]
+                if (token.startsWith("-")) {
+                    val value = tokens.getOrNull(i + 1)
+                    if (value != null && !value.startsWith("-")) {
+                        params[token.removePrefix("-")] = value
+                        i += 2
+                        continue
+                    }
+                }
+                i++
+            }
+            return ModelSetCommand(params)
         }
 
         if (trimmedMessage.startsWith("/model ")) {

--- a/src/test/kotlin/com/github/fmueller/jarvis/commands/ModelCommandTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/commands/ModelCommandTest.kt
@@ -57,8 +57,9 @@ class ModelCommandTest : TestCase() {
             OllamaService.host = originalHost
             server.stop(0)
         }
-        val expectedFormattedOutput = " Model\n\n  Parameters\n\n  License\n    test"
-        assertEquals(expectedFormattedOutput, conversation.messages.last().content)
+        val content = conversation.messages.last().content
+        assertTrue(content.startsWith(" Model\n\n  Parameters"))
+        assertTrue(content.contains("Inference parameters"))
         assertEquals(Role.INFO, conversation.messages.last().role)
     }
 }

--- a/src/test/kotlin/com/github/fmueller/jarvis/commands/ModelSetCommandTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/commands/ModelSetCommandTest.kt
@@ -1,0 +1,22 @@
+package com.github.fmueller.jarvis.commands
+
+import com.github.fmueller.jarvis.ai.OllamaService
+import com.github.fmueller.jarvis.conversation.Conversation
+import junit.framework.TestCase
+import kotlinx.coroutines.runBlocking
+
+class ModelSetCommandTest : TestCase() {
+
+    override fun setUp() {
+        super.setUp()
+        OllamaService.temperature = 0.7
+    }
+
+    fun `test run sets parameter`() = runBlocking {
+        val conversation = Conversation()
+        ModelSetCommand(mapOf("temperature" to "1.0")).run(conversation)
+        assertEquals(1.0, OllamaService.temperature)
+        assertEquals("Parameters updated", conversation.messages.last().content)
+    }
+}
+

--- a/src/test/kotlin/com/github/fmueller/jarvis/commands/SlashCommandParserTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/commands/SlashCommandParserTest.kt
@@ -34,6 +34,11 @@ class SlashCommandParserTest : TestCase() {
         assertTrue(command is ModelCommand)
     }
 
+    fun `test parse model set returns ModelSetCommand`() {
+        val command = SlashCommandParser.parse("/model set -temperature 1.0")
+        assertTrue(command is ModelSetCommand)
+    }
+
     fun `test parse host returns HostCommand`() {
         val command = SlashCommandParser.parse("/host http://1.2.3.4")
         assertTrue(command is HostCommand)


### PR DESCRIPTION
## Summary
- allow configuring Ollama inference parameters with `/model set -<parameter> <value>`
- list current parameter values in `/model info`
- document model parameter command

## Testing
- `gradle build`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_68b196cbb804832d80210ba3752f2620