### PR TITLE
feat: keep Ollama model alive for five minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove caches for closed pull requests in CI
 - Configurable context window size when calling Ollama
 - `/model` shows model info when no name is supplied and new `/model-info` command
+- Keep the current Ollama model in memory for five minutes
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 <!-- Plugin description -->
 Jarvis is an LLM-powered developer plugin for the JetBrains IDE platform. It aims to support developers by leveraging
-local LLMs only. To achieve this, it is integrating with Ollama.
+local LLMs only. To achieve this, it is integrating with Ollama. Jarvis keeps the currently used model in memory for
+five minutes to reduce loading times.
 <!-- Plugin description end -->
 
 ## Installation

--- a/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
+++ b/src/main/kotlin/com/github/fmueller/jarvis/ai/OllamaService.kt
@@ -7,6 +7,7 @@ import com.github.fmueller.jarvis.conversation.Message
 import com.intellij.lang.Language
 import dev.langchain4j.memory.chat.TokenWindowChatMemory
 import dev.langchain4j.model.ollama.OllamaStreamingChatModel
+import dev.langchain4j.model.ollama.OllamaChatRequestParameters
 import dev.langchain4j.service.AiServices
 import dev.langchain4j.service.TokenStream
 import kotlinx.coroutines.*
@@ -442,6 +443,11 @@ object OllamaService {
                     .baseUrl(host)
                     .modelName(modelName)
                     .numCtx(contextWindowSize)
+                    .defaultRequestParameters(
+                        OllamaChatRequestParameters.builder()
+                            .keepAlive(Duration.ofMinutes(5).toSeconds().toInt())
+                            .build()
+                    )
                     .build()
             )
             .systemMessageProvider { chatMemoryId -> systemPrompt }

--- a/src/test/kotlin/com/github/fmueller/jarvis/ai/OllamaServiceKeepAliveTest.kt
+++ b/src/test/kotlin/com/github/fmueller/jarvis/ai/OllamaServiceKeepAliveTest.kt
@@ -1,0 +1,26 @@
+package com.github.fmueller.jarvis.ai
+
+import dev.langchain4j.model.ollama.OllamaStreamingChatModel
+import junit.framework.TestCase
+import java.lang.reflect.Proxy
+
+class OllamaServiceKeepAliveTest : TestCase() {
+
+    fun `test keep alive is five minutes`() {
+        val assistantField = OllamaService::class.java.getDeclaredField("assistant")
+        assistantField.isAccessible = true
+        val assistant = assistantField.get(OllamaService)
+        val handler = Proxy.getInvocationHandler(assistant)
+        val outerField = handler.javaClass.getDeclaredField("this$0")
+        outerField.isAccessible = true
+        val defaultAiServices = outerField.get(handler)
+        val contextField = defaultAiServices.javaClass.superclass.getDeclaredField("context")
+        contextField.isAccessible = true
+        val context = contextField.get(defaultAiServices)
+        val streamingChatModelField = context.javaClass.getDeclaredField("streamingChatModel")
+        streamingChatModelField.isAccessible = true
+        val streamingChatModel = streamingChatModelField.get(context) as OllamaStreamingChatModel
+        val keepAlive = streamingChatModel.defaultRequestParameters().keepAlive()
+        assertEquals(300, keepAlive)
+    }
+}


### PR DESCRIPTION
## Summary
- keep current model loaded for five minutes via keep_alive parameter
- document model cache behavior and update changelog
- test keep-alive configuration

## Testing
- `gradle build`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_68b1a278c59c832db1da290e9229842f